### PR TITLE
[#35] refactor: DB 정규화 및 로그 처리

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
@@ -33,6 +34,7 @@ dependencies {
     kapt("jakarta.persistence:jakarta.persistence-api")
 
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13")
+	implementation("net.logstash.logback:logstash-logback-encoder:8.0")
 
     runtimeOnly("com.mysql:mysql-connector-j")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/org/example/beyondubackend/common/annotation/LogMask.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/annotation/LogMask.kt
@@ -1,0 +1,5 @@
+package org.example.beyondubackend.common.annotation
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LogMask

--- a/src/main/kotlin/org/example/beyondubackend/common/annotation/Loggable.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/annotation/Loggable.kt
@@ -1,0 +1,9 @@
+package org.example.beyondubackend.common.annotation
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Loggable(
+    val level: LogLevel = LogLevel.INFO
+)
+
+enum class LogLevel { INFO, DEBUG }

--- a/src/main/kotlin/org/example/beyondubackend/common/config/JpaConfig.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/config/JpaConfig.kt
@@ -1,0 +1,8 @@
+package org.example.beyondubackend.common.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@Configuration
+@EnableJpaAuditing
+class JpaConfig

--- a/src/main/kotlin/org/example/beyondubackend/common/config/LoggingAspect.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/config/LoggingAspect.kt
@@ -1,0 +1,67 @@
+package org.example.beyondubackend.common.config
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import org.example.beyondubackend.common.annotation.LogLevel
+import org.example.beyondubackend.common.annotation.LogMask
+import org.example.beyondubackend.common.annotation.Loggable
+import org.example.beyondubackend.common.exception.BusinessException
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class LoggingAspect {
+
+    @Around(
+        "@within(org.example.beyondubackend.common.annotation.Loggable) || " +
+        "@annotation(org.example.beyondubackend.common.annotation.Loggable)"
+    )
+    fun log(joinPoint: ProceedingJoinPoint): Any? {
+        val signature = joinPoint.signature as MethodSignature
+        val method = signature.method
+        val targetClass = joinPoint.target.javaClass
+
+        val loggable = method.getAnnotation(Loggable::class.java)
+            ?: targetClass.getAnnotation(Loggable::class.java)
+            ?: return joinPoint.proceed()
+
+        val logger = LoggerFactory.getLogger(targetClass)
+        val methodName = "${targetClass.simpleName}.${method.name}"
+        val args = buildArgString(joinPoint, signature)
+
+        logAt(logger, loggable.level, "[IN]  $methodName args=$args")
+
+        val start = System.currentTimeMillis()
+        return try {
+            val result = joinPoint.proceed()
+            val elapsed = System.currentTimeMillis() - start
+            logAt(logger, loggable.level, "[OUT] $methodName elapsed=${elapsed}ms")
+            result
+        } catch (e: BusinessException) {
+            // BusinessException 로깅은 GlobalExceptionHandler에 위임
+            throw e
+        } catch (e: Exception) {
+            val elapsed = System.currentTimeMillis() - start
+            logger.error("[ERR] $methodName elapsed=${elapsed}ms exception=${e.message}", e)
+            throw e
+        }
+    }
+
+    private fun buildArgString(joinPoint: ProceedingJoinPoint, signature: MethodSignature): String {
+        val params = signature.method.parameters
+        return joinPoint.args.mapIndexed { i, arg ->
+            val isMasked = params.getOrNull(i)?.isAnnotationPresent(LogMask::class.java) == true
+            if (isMasked) "****" else arg
+        }.toString()
+    }
+
+    private fun logAt(logger: org.slf4j.Logger, level: LogLevel, message: String) {
+        when (level) {
+            LogLevel.INFO -> logger.info(message)
+            LogLevel.DEBUG -> logger.debug(message)
+        }
+    }
+}

--- a/src/main/kotlin/org/example/beyondubackend/common/enums/ExamType.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/enums/ExamType.kt
@@ -4,15 +4,17 @@ enum class ExamType(
     val paramName: String,
     val displayName: String,
     val minScore: Double,
-    val maxScore: Double
+    val maxScore: Double,
+    val prefix: String = "",
+    val suffix: String = ""
 ) {
     TOEFL_IBT("TOEFL_IBT", "TOEFL iBT", 0.0, 120.0),
     TOEFL_ITP("TOEFL_ITP", "TOEFL ITP", 0.0, 677.0),
     IELTS("IELTS", "IELTS", 0.0, 9.0),
     TOEIC("TOEIC", "TOEIC", 0.0, 990.0),
     TOEIC_SPEAKING("TOEIC_Speaking", "TOEIC Speaking", 0.0, 200.0),
-    HSK("HSK", "HSK", 1.0, 6.0),
-    JLPT("JLPT", "JLPT", 1.0, 5.0),
+    HSK("HSK", "HSK", 1.0, 6.0, suffix = "급"),
+    JLPT("JLPT", "JLPT", 1.0, 5.0, prefix = "N"),
     JPT("JPT", "JPT", 0.0, 990.0),
     DELF("DELF", "DELF", 1.0, 6.0),
     ZD("ZD", "ZD", 1.0, 6.0);

--- a/src/main/kotlin/org/example/beyondubackend/common/filter/TraceIdFilter.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/filter/TraceIdFilter.kt
@@ -1,0 +1,27 @@
+package org.example.beyondubackend.common.filter
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.*
+
+@Component
+class TraceIdFilter : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val traceId = UUID.randomUUID().toString().replace("-", "").take(16)
+        try {
+            MDC.put("traceId", traceId)
+            filterChain.doFilter(request, response)
+        } finally {
+            MDC.clear()
+        }
+    }
+}

--- a/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/implement/LanguageRequirement.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/implement/LanguageRequirement.kt
@@ -6,6 +6,5 @@ class LanguageRequirement(
     var languageGroup: String,
     var examType: String,
     var minScore: Double,
-    var levelCode: String? = null,
-    var isAvailable: Boolean = true
+    var levelCode: String? = null
 )

--- a/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/implement/LanguageRequirementReader.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/implement/LanguageRequirementReader.kt
@@ -20,17 +20,13 @@ class LanguageRequirementReader(
         if (requirements.isEmpty()) return null
 
         return requirements.joinToString(" / ") { requirement ->
-            when {
-                requirement.examType.equals(ExamType.HSK.displayName, ignoreCase = true) && requirement.levelCode != null -> {
-                    "${ExamType.HSK.displayName} ${requirement.levelCode}"
-                }
-                requirement.examType.equals(ExamType.HSK.displayName, ignoreCase = true) -> {
-                    "${ExamType.HSK.displayName} ${requirement.minScore.toInt()}"
-                }
-                else -> {
-                    "${requirement.examType} ${formatScore(requirement.minScore)}"
-                }
+            val examType = ExamType.fromDisplayName(requirement.examType)
+            val scoreText = if (examType != null) {
+                "${examType.prefix}${formatScore(requirement.minScore)}${examType.suffix}"
+            } else {
+                formatScore(requirement.minScore)
             }
+            "${requirement.examType} $scoreText"
         }
     }
 

--- a/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/storage/LanguageRequirementEntity.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/storage/LanguageRequirementEntity.kt
@@ -23,10 +23,7 @@ class LanguageRequirementEntity(
     var minScore: Double,
 
     @Column(name = "level_code")
-    var levelCode: String? = null,
-
-    @Column(name = "is_available", nullable = false)
-    var isAvailable: Boolean = true
+    var levelCode: String? = null
 ) {
     companion object {
         fun from(languageRequirement: LanguageRequirement) =
@@ -36,8 +33,7 @@ class LanguageRequirementEntity(
                 languageGroup = languageRequirement.languageGroup,
                 examType = languageRequirement.examType,
                 minScore = languageRequirement.minScore,
-                levelCode = languageRequirement.levelCode,
-                isAvailable = languageRequirement.isAvailable
+                levelCode = languageRequirement.levelCode
             )
     }
 
@@ -48,8 +44,7 @@ class LanguageRequirementEntity(
             languageGroup = languageGroup,
             examType = examType,
             minScore = minScore,
-            levelCode = levelCode,
-            isAvailable = isAvailable
+            levelCode = levelCode
         )
     }
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/storage/LanguageRequirementJpaRepository.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/storage/LanguageRequirementJpaRepository.kt
@@ -3,6 +3,6 @@ package org.example.beyondubackend.domain.languagerequirement.storage
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface LanguageRequirementJpaRepository : JpaRepository<LanguageRequirementEntity, Long> {
-    fun findByUniversityIdAndIsAvailableTrue(universityId: Long): List<LanguageRequirementEntity>
-    fun findByIsAvailableTrue(): List<LanguageRequirementEntity>
+    fun findByUniversityId(universityId: Long): List<LanguageRequirementEntity>
+    fun findByUniversityIdIn(universityIds: List<Long>): List<LanguageRequirementEntity>
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/storage/LanguageRequirementRepositoryImpl.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/storage/LanguageRequirementRepositoryImpl.kt
@@ -10,15 +10,14 @@ class LanguageRequirementRepositoryImpl(
 ) : LanguageRequirementRepository {
 
     override fun findByUniversityId(universityId: Long): List<LanguageRequirement> {
-        return languageRequirementJpaRepository.findByUniversityIdAndIsAvailableTrue(universityId)
+        return languageRequirementJpaRepository.findByUniversityId(universityId)
             .map { it.toDomain() }
     }
 
     override fun findByUniversityIds(universityIds: List<Long>): Map<Long, List<LanguageRequirement>> {
         if (universityIds.isEmpty()) return emptyMap()
 
-        return languageRequirementJpaRepository.findByIsAvailableTrue()
-            .filter { it.universityId in universityIds }
+        return languageRequirementJpaRepository.findByUniversityIdIn(universityIds)
             .groupBy { it.universityId }
             .mapValues { entry -> entry.value.map { it.toDomain() } }
     }

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/application/UniversityController.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/application/UniversityController.kt
@@ -9,21 +9,16 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.example.beyondubackend.common.annotation.ExamScoreParams
 import org.example.beyondubackend.common.dto.ApiResponse
 import org.example.beyondubackend.domain.university.application.dto.UniversitySearchRequest
-import org.example.beyondubackend.domain.university.business.UniversityService
 import org.example.beyondubackend.domain.university.business.dto.UniversityDetailResponse
 import org.example.beyondubackend.domain.university.business.dto.UniversityListResponse
 import org.springdoc.core.annotations.ParameterObject
-import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Sort
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
 
 @Tag(name = "University", description = "대학교 조회 API")
-@RestController
-@RequestMapping("/api/v1/universities")
-class UniversityController(
-    private val universityService: UniversityService
-) {
+interface UniversityController {
 
     @Operation(
         summary = "대학교 목록 조회",
@@ -77,7 +72,6 @@ class UniversityController(
             required = false, `in` = ParameterIn.QUERY, schema = Schema(type = "number", example = "4")
         )
     ])
-    @GetMapping
     fun getUniversities(
         @ParameterObject @ModelAttribute request: UniversitySearchRequest,
         @Parameter(hidden = true) @ExamScoreParams examScores: Map<String, Double>,
@@ -85,23 +79,14 @@ class UniversityController(
         @RequestParam(defaultValue = "0") page: Int,
         @Parameter(description = "페이지 크기", example = "12")
         @RequestParam(defaultValue = "12") size: Int
-    ): ResponseEntity<ApiResponse<UniversityListResponse>> {
-        val pageable = PageRequest.of(page, size, Sort.by(Sort.Order.asc("nameEng"), Sort.Order.asc("nameKor")))
-        val query = request.toQuery(examScores)
-        val result = universityService.getUniversities(query, pageable)
-        return ApiResponse.success(result)
-    }
+    ): ResponseEntity<ApiResponse<UniversityListResponse>>
 
     @Operation(
         summary = "대학교 상세 조회",
         description = "대학교 ID로 상세 정보를 조회합니다. 언어 요구사항 정보도 함께 반환됩니다."
     )
-    @GetMapping("/{id}")
     fun getUniversityDetail(
         @Parameter(description = "대학교 ID", example = "1", required = true)
         @PathVariable id: Long
-    ): ResponseEntity<ApiResponse<UniversityDetailResponse>> {
-        val result = universityService.getUniversityDetail(id)
-        return ApiResponse.success(result)
-    }
+    ): ResponseEntity<ApiResponse<UniversityDetailResponse>>
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/application/UniversityControllerImpl.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/application/UniversityControllerImpl.kt
@@ -1,0 +1,41 @@
+package org.example.beyondubackend.domain.university.application
+
+import org.example.beyondubackend.common.annotation.ExamScoreParams
+import org.example.beyondubackend.common.dto.ApiResponse
+import org.example.beyondubackend.domain.university.application.dto.UniversitySearchRequest
+import org.example.beyondubackend.domain.university.business.UniversityService
+import org.example.beyondubackend.domain.university.business.dto.UniversityDetailResponse
+import org.example.beyondubackend.domain.university.business.dto.UniversityListResponse
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/universities")
+class UniversityControllerImpl(
+    private val universityService: UniversityService
+) : UniversityController {
+
+    @GetMapping
+    override fun getUniversities(
+        @ParameterObject @ModelAttribute request: UniversitySearchRequest,
+        @ExamScoreParams examScores: Map<String, Double>,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "12") size: Int
+    ): ResponseEntity<ApiResponse<UniversityListResponse>> {
+        val pageable = PageRequest.of(page, size, Sort.by(Sort.Order.asc("nameEng"), Sort.Order.asc("nameKor")))
+        val query = request.toQuery(examScores)
+        val result = universityService.getUniversities(query, pageable)
+        return ApiResponse.success(result)
+    }
+
+    @GetMapping("/{id}")
+    override fun getUniversityDetail(
+        @PathVariable id: Long
+    ): ResponseEntity<ApiResponse<UniversityDetailResponse>> {
+        val result = universityService.getUniversityDetail(id)
+        return ApiResponse.success(result)
+    }
+}

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/business/UniversityServiceImpl.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/business/UniversityServiceImpl.kt
@@ -60,7 +60,7 @@ class UniversityServiceImpl(
 
     override fun getUniversityDetail(id: Long): UniversityDetailResponse {
         val university = universityReader.getUniversityById(id)
-        val languageRequirements = universityReader.getLanguageRequirementsByUniversityId(id)
+        val languageRequirements = languageRequirementReader.findByUniversityId(id)
             .map { LanguageRequirementResponse.from(it) }
 
         return UniversityDetailResponse.from(university, languageRequirements)

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/business/dto/UniversityDetailResponse.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/business/dto/UniversityDetailResponse.kt
@@ -50,62 +50,15 @@ data class UniversityDetailResponse(
                 significantNote = university.significantNote,
                 remark = university.remark,
                 languageRequirements = languageRequirements,
-                availableMajors = parseAvailableMajors(university.availableMajors),
-                courseListUrl = parseCourseListUrl(university.availableMajors),
-                studentCount = parseStudentCount(university.remark),
-                location = parseLocation(university.remark),
+                availableMajors = university.availableMajor
+                    ?.split(",")
+                    ?.map { it.trim() }
+                    ?.filter { it.isNotBlank() }
+                    ?.takeIf { it.isNotEmpty() },
+                courseListUrl = university.availableSubject,
+                studentCount = university.studentCount,
+                location = university.location,
             )
-        }
-
-        /**
-         * availableMajors에서 수학 가능 학과 리스트 파싱
-         * 예: "★ 수학가능학과: Architecture, Arts and Sciences, ..." -> ["Architecture", "Arts and Sciences", ...]
-         */
-        private fun parseAvailableMajors(availableMajors: String?): List<String>? {
-            if (availableMajors == null) return null
-            val regex = """★\s*수학가능학과:\s*([^★]+)""".toRegex()
-            val matchResult = regex.find(availableMajors) ?: return null
-            val majorsText = matchResult.groupValues[1].trim()
-
-            return majorsText
-                .split(",")
-                .map { it.trim() }
-                .filter { it.isNotBlank() }
-                .takeIf { it.isNotEmpty() }
-        }
-
-        /**
-         * availableMajors에서 수강가능과목 URL 파싱
-         * 예: "★ 수강가능과목(2025): https://..." -> "https://..."
-         */
-        private fun parseCourseListUrl(availableMajors: String?): String? {
-            if (availableMajors == null) return null
-            val regex = """★\s*수강가능과목[^:]*:\s*(https?://\S+)""".toRegex()
-            return regex.find(availableMajors)?.groupValues?.get(1)?.trim()
-        }
-
-        /**
-         * remark에서 위치 파싱
-         * 예: "* 위치: Vechta\n* 특징: ..." -> "Vechta"
-         * 예: "* 위치: Brühl (쾰른에서 기차로 10분) * 특징: ..." -> "Brühl (쾰른에서 기차로 10분)"
-         * 없으면 null 반환
-         */
-        private fun parseLocation(remark: String?): String? {
-            if (remark == null) return null
-            val regex = """\*\s*위치\s*:\s*([^*\n]+)""".toRegex()
-            return regex.find(remark)?.groupValues?.get(1)?.trim()?.takeIf { it.isNotBlank() }
-        }
-
-        /**
-         * remark에서 학생 수 파싱
-         * 예: "... 학생 수 약 28,600명 ..." -> "약 28,600명"
-         * 없으면 "학생 수 정보 없음" 반환
-         */
-        private fun parseStudentCount(remark: String?): String {
-            if (remark == null) return "학생 수 정보 없음"
-            val regex = """학생\s*수\s*약?\s*([\d,]+)\s*명""".toRegex()
-            val count = regex.find(remark)?.groupValues?.get(1)?.trim()
-            return if (count != null) "약 $count 명" else "학생 수 정보 없음"
         }
     }
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/implement/University.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/implement/University.kt
@@ -9,13 +9,15 @@ class University(
     var nameEng: String,
     var minGpa: Double,
     var significantNote: String? = null,
-    var remark: String? = null,
-    var availableMajors: String? = null,
+    var remark: String,
+    var location: String? = null,
+    var studentCount: String? = null,
+    var availableMajor: String? = null,
+    var availableSubject: String? = null,
     var websiteUrl: String? = null,
     var isExchange: Boolean,
     var isVisit: Boolean,
     var badge: String = "",
     var hasReview: Boolean = false,
-    var reviewYear: String? = null,
-    var languageScore: String? = null
+    var reviewYear: String? = null
 )

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/implement/UniversityReader.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/implement/UniversityReader.kt
@@ -2,16 +2,13 @@ package org.example.beyondubackend.domain.university.implement
 
 import org.example.beyondubackend.common.code.ErrorCode
 import org.example.beyondubackend.common.exception.BusinessException
-import org.example.beyondubackend.domain.languagerequirement.implement.LanguageRequirement
-import org.example.beyondubackend.domain.languagerequirement.storage.LanguageRequirementJpaRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 
 @Component
 class UniversityReader(
-    private val universityRepository: UniversityRepository,
-    private val languageRequirementJpaRepository: LanguageRequirementJpaRepository
+    private val universityRepository: UniversityRepository
 ) {
 
     fun getUniversitiesWithFilters(
@@ -33,10 +30,5 @@ class UniversityReader(
     fun getUniversityById(id: Long): University {
         return universityRepository.findById(id)
             ?: throw BusinessException(ErrorCode.UNIVERSITY_NOT_FOUND)
-    }
-
-    fun getLanguageRequirementsByUniversityId(universityId: Long): List<LanguageRequirement> {
-        return languageRequirementJpaRepository.findByUniversityIdAndIsAvailableTrue(universityId)
-            .map { it.toDomain() }
     }
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/storage/UniversityEntity.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/storage/UniversityEntity.kt
@@ -1,6 +1,7 @@
 package org.example.beyondubackend.domain.university.storage
 
 import jakarta.persistence.*
+import org.example.beyondubackend.common.entity.BaseEntity
 import org.example.beyondubackend.domain.university.implement.University
 
 @Entity
@@ -31,13 +32,22 @@ class UniversityEntity(
     @Column(name = "significant_note", columnDefinition = "TEXT", nullable = true)
     var significantNote: String? = null,
 
-    @Column(columnDefinition = "TEXT", nullable = true)
-    var remark: String? = null,
+    @Column(columnDefinition = "TEXT", nullable = false)
+    var remark: String,
 
-    @Column(columnDefinition = "TEXT", name = "available_majors", nullable = true)
-    var availableMajors: String? = null,
+    @Column(name = "location", nullable = true)
+    var location: String? = null,
 
-    @Column(name="website_url", nullable = true)
+    @Column(name = "student_count", nullable = true)
+    var studentCount: String? = null,
+
+    @Column(columnDefinition = "TEXT", name = "available_major", nullable = true)
+    var availableMajor: String? = null,
+
+    @Column(columnDefinition = "TEXT", name = "available_subject", nullable = true)
+    var availableSubject: String? = null,
+
+    @Column(name = "website_url", columnDefinition = "TEXT", nullable = true)
     var websiteUrl: String? = null,
 
     @Column(name = "is_exchange", nullable = false)
@@ -46,22 +56,18 @@ class UniversityEntity(
     @Column(name = "is_visit", nullable = false)
     var isVisit: Boolean,
 
-    @Column(nullable = false)
-    var badge: String = "",
+    @Column(nullable = true)
+    var badge: String? = null,
 
     @Column(name = "has_review", nullable = false)
     var hasReview: Boolean = false,
 
     @Column(name = "review_year", nullable = true)
-    var reviewYear: String? = null,
+    var reviewYear: String? = null
 
-    @Column(name = "language_score", columnDefinition = "TEXT", nullable = true)
-    var languageScore: String? = null
-
-) {
+) : BaseEntity() {
     companion object {
         fun from(university: University) = UniversityEntity(
-
             id = university.id,
             semester = university.semester,
             region = university.region,
@@ -71,14 +77,16 @@ class UniversityEntity(
             minGpa = university.minGpa,
             significantNote = university.significantNote,
             remark = university.remark,
-            availableMajors = university.availableMajors,
+            location = university.location,
+            studentCount = university.studentCount,
+            availableMajor = university.availableMajor,
+            availableSubject = university.availableSubject,
             websiteUrl = university.websiteUrl,
             isExchange = university.isExchange,
             isVisit = university.isVisit,
             badge = university.badge,
             hasReview = university.hasReview,
-            reviewYear = university.reviewYear,
-            languageScore = university.languageScore
+            reviewYear = university.reviewYear
         )
     }
 
@@ -93,14 +101,16 @@ class UniversityEntity(
             minGpa = minGpa,
             significantNote = significantNote,
             remark = remark,
-            availableMajors = availableMajors,
+            location = location,
+            studentCount = studentCount,
+            availableMajor = availableMajor,
+            availableSubject = availableSubject,
             websiteUrl = websiteUrl,
             isExchange = isExchange,
             isVisit = isVisit,
-            badge = badge,
+            badge = badge ?: "",
             hasReview = hasReview,
-            reviewYear = reviewYear,
-            languageScore = languageScore
+            reviewYear = reviewYear
         )
     }
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/storage/UniversityRepositoryImpl.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/storage/UniversityRepositoryImpl.kt
@@ -109,7 +109,7 @@ class UniversityRepositoryImpl(
     }
 
     private fun majorContains(major: String?): BooleanExpression? {
-        return major?.let { universityEntity.availableMajors.contains(it) }
+        return major?.let { universityEntity.availableMajor.contains(it) }
     }
 
     private fun hasReviewEq(hasReview: Boolean?): BooleanExpression? {
@@ -136,7 +136,6 @@ class UniversityRepositoryImpl(
             .from(languageRequirementEntity)
             .where(
                 languageRequirementEntity.universityId.eq(universityEntity.id),
-                languageRequirementEntity.isAvailable.eq(true),
                 examConditions
             )
             .exists()

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- 공통 CONSOLE appender — test/dev 공유 (색상 없음) -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%X{traceId:-no-trace}] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 컬러 CONSOLE appender — local 전용 -->
+    <appender name="CONSOLE_COLOR" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%gray(%d{HH:mm:ss.SSS}) %blue([%X{traceId:-no-trace}]) %highlight(%-5level) %cyan(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- ─────────────────────────────────────────
+         TEST — 로그 출력 확인용
+    ───────────────────────────────────────── -->
+    <springProfile name="test">
+        <root level="WARN">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+        <logger name="org.example.beyondubackend" level="DEBUG" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+        </logger>
+    </springProfile>
+
+    <!-- ─────────────────────────────────────────
+         LOCAL — 컬러 콘솔
+    ───────────────────────────────────────── -->
+    <springProfile name="local">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE_COLOR"/>
+        </root>
+        <logger name="org.example.beyondubackend" level="DEBUG" additivity="false">
+            <appender-ref ref="CONSOLE_COLOR"/>
+        </logger>
+    </springProfile>
+
+    <!-- ─────────────────────────────────────────
+         DEV — 콘솔
+    ───────────────────────────────────────── -->
+    <springProfile name="dev">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <!-- ─────────────────────────────────────────
+         PROD — JSON (Loki 수집)
+    ───────────────────────────────────────── -->
+    <springProfile name="prod">
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>logs/app.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>logs/app.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <includeMdcKeyName>traceId</includeMdcKeyName>
+                <fieldNames>
+                    <timestamp>timestamp</timestamp>
+                    <message>message</message>
+                    <logger>logger</logger>
+                    <level>level</level>
+                </fieldNames>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="FILE"/>
+        </root>
+    </springProfile>
+
+</configuration>

--- a/src/test/kotlin/org/example/beyondubackend/common/LoggingAspectTest.kt
+++ b/src/test/kotlin/org/example/beyondubackend/common/LoggingAspectTest.kt
@@ -1,0 +1,43 @@
+package org.example.beyondubackend.common
+
+import org.example.beyondubackend.common.annotation.LogMask
+import org.example.beyondubackend.common.annotation.Loggable
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.stereotype.Service
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("test")
+class LoggingAspectTest {
+
+    @Autowired
+    lateinit var sampleService: SampleService
+
+    @Test
+    fun `@Loggable 로그 출력 확인`() {
+        sampleService.search("하버드", 3.5)
+    }
+
+    @Test
+    fun `@LogMask 마스킹 확인`() {
+        sampleService.login("user@example.com", "secret1234")
+    }
+}
+
+@Service
+class SampleService {
+
+    @Loggable
+    fun search(keyword: String, gpa: Double): String {
+        Thread.sleep(30)
+        return "result:$keyword"
+    }
+
+    @Loggable
+    fun login(email: String, @LogMask password: String): Boolean {
+        Thread.sleep(10)
+        return true
+    }
+}

--- a/src/test/kotlin/org/example/beyondubackend/domain/university/flow/UniversityFlowTest.kt
+++ b/src/test/kotlin/org/example/beyondubackend/domain/university/flow/UniversityFlowTest.kt
@@ -1,0 +1,498 @@
+package org.example.beyondubackend.domain.university.flow
+
+import org.assertj.core.api.Assertions.assertThat
+import org.example.beyondubackend.domain.languagerequirement.storage.LanguageRequirementEntity
+import org.example.beyondubackend.domain.languagerequirement.storage.LanguageRequirementJpaRepository
+import org.example.beyondubackend.domain.university.storage.UniversityEntity
+import org.example.beyondubackend.domain.university.storage.UniversityJpaRepository
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class UniversityFlowTest {
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    @Autowired
+    private lateinit var restTemplate: TestRestTemplate
+
+    @Autowired
+    private lateinit var universityJpaRepository: UniversityJpaRepository
+
+    @Autowired
+    private lateinit var languageRequirementJpaRepository: LanguageRequirementJpaRepository
+
+    private val baseUrl get() = "http://localhost:$port/api/v1/universities"
+
+    // ── 픽스처 ──────────────────────────────────────────────────────────────
+    // uni1: USA, GPA 3.0, 교환, TOEFL iBT 80 / IELTS 6.0, 후기 있음
+    // uni2: JPN, GPA 3.5, 교환, JLPT N2(minScore=2)
+    // uni3: USA, GPA 2.5, 방문, 어학 요구사항 없음
+    // uni4: CHN, GPA 3.8, 교환, TOEFL iBT 100, 후기 있음
+    // uni5: AUS, GPA 2.0, 교환, 어학 요구사항 없음
+
+    private lateinit var uni1: UniversityEntity
+    private lateinit var uni2: UniversityEntity
+    private lateinit var uni3: UniversityEntity
+    private lateinit var uni4: UniversityEntity
+    private lateinit var uni5: UniversityEntity
+
+    @BeforeEach
+    fun setUp() {
+        languageRequirementJpaRepository.deleteAll()
+        universityJpaRepository.deleteAll()
+
+        uni1 = universityJpaRepository.save(makeUniversity(
+            nameKor = "하버드대학교", nameEng = "Harvard University",
+            nation = "USA", minGpa = 3.0,
+            isExchange = true, isVisit = false,
+            hasReview = true, reviewYear = "2024",
+            availableMajor = "Arts and Sciences, Business",
+            location = "Cambridge, MA", studentCount = "47,000"
+        ))
+        uni2 = universityJpaRepository.save(makeUniversity(
+            nameKor = "도쿄대학교", nameEng = "University of Tokyo",
+            nation = "JPN", minGpa = 3.5,
+            isExchange = true, isVisit = false,
+            availableMajor = "Engineering",
+            location = "Tokyo, Japan", studentCount = "28,000"
+        ))
+        uni3 = universityJpaRepository.save(makeUniversity(
+            nameKor = "캘리포니아주립대", nameEng = "California State University",
+            nation = "USA", minGpa = 2.5,
+            isExchange = false, isVisit = true,
+            location = "Los Angeles, CA"
+        ))
+        uni4 = universityJpaRepository.save(makeUniversity(
+            nameKor = "베이징대학교", nameEng = "Peking University",
+            nation = "CHN", minGpa = 3.8,
+            isExchange = true, isVisit = false,
+            hasReview = true, reviewYear = "2023",
+            availableMajor = "Business, Economics",
+            location = "Beijing, China", studentCount = "55,000"
+        ))
+        uni5 = universityJpaRepository.save(makeUniversity(
+            nameKor = "멜버른대학교", nameEng = "University of Melbourne",
+            nation = "AUS", minGpa = 2.0,
+            isExchange = true, isVisit = false
+        ))
+
+        languageRequirementJpaRepository.saveAll(listOf(
+            makeLangReq(uni1.id!!, "영어", "TOEFL iBT", 80.0),
+            makeLangReq(uni1.id!!, "영어", "IELTS", 6.0),
+            makeLangReq(uni2.id!!, "일본어", "JLPT", 2.0),
+            makeLangReq(uni4.id!!, "영어", "TOEFL iBT", 100.0)
+        ))
+    }
+
+    @AfterEach
+    fun tearDown() {
+        languageRequirementJpaRepository.deleteAll()
+        universityJpaRepository.deleteAll()
+    }
+
+    // ── 전체 조회: 파라미터 없음 ────────────────────────────────────────────
+
+    @Test
+    fun `파라미터 없이 전체 조회 시 5개 대학이 모두 반환된다`() {
+        val response = get<Map<String, Any?>>(baseUrl)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        val universities = universities(response)
+        assertThat(universities).hasSize(5)
+    }
+
+    // ── 전체 조회: GPA 필터 ─────────────────────────────────────────────────
+
+    @Test
+    fun `GPA 3점 입력 시 minGpa 3점 이하 대학(uni1 uni3 uni5)만 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?gpa=3.0")
+
+        val ids = universityIds(response)
+        assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni3.id, uni5.id)
+    }
+
+    @Test
+    fun `GPA 3점5 입력 시 minGpa 3점5 이하 대학 4개가 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?gpa=3.5")
+
+        val ids = universityIds(response)
+        assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni2.id, uni3.id, uni5.id)
+    }
+
+    @Test
+    fun `내 GPA보다 요구 GPA가 높은 대학은 결과에 포함되지 않는다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?gpa=2.0")
+
+        val ids = universityIds(response)
+        assertThat(ids).containsOnly(uni5.id)
+    }
+
+    // ── 전체 조회: 어학 점수 단독 필터 ─────────────────────────────────────
+
+    @Test
+    fun `TOEFL IBT 80점 보유 시 충족 대학과 어학 요구사항 없는 대학이 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?TOEFL_IBT=80")
+
+        val ids = universityIds(response)
+        // uni1: TOEFL iBT 80 충족, uni3/uni5: 어학 요구사항 없음
+        assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni3.id, uni5.id)
+    }
+
+    @Test
+    fun `보유 TOEFL 점수가 대학 요구 점수보다 낮으면 해당 대학은 제외된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?TOEFL_IBT=79")
+
+        val ids = universityIds(response)
+        // uni1 TOEFL 80 요구 → 79 < 80 → 제외, uni4 TOEFL 100 요구 → 제외
+        assertThat(ids).doesNotContain(uni1.id, uni4.id)
+        assertThat(ids).containsExactlyInAnyOrder(uni3.id, uni5.id)
+    }
+
+    @Test
+    fun `어학 요구사항이 없는 대학은 어학 필터와 무관하게 항상 조회된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?TOEFL_IBT=120")
+
+        val ids = universityIds(response)
+        assertThat(ids).contains(uni3.id, uni5.id)
+    }
+
+    // ── 전체 조회: GPA + 어학 복합 필터 ────────────────────────────────────
+
+    @Test
+    fun `GPA 3점5 + TOEFL IBT 80점 조합 시 조건을 모두 충족하는 대학만 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?gpa=3.5&TOEFL_IBT=80")
+
+        val ids = universityIds(response)
+        // uni1(GPA 3.0 ≤ 3.5, TOEFL 80 충족), uni3(GPA 2.5, 어학없음), uni5(GPA 2.0, 어학없음)
+        // uni2(GPA 3.5, JLPT만 있어 TOEFL 불충족), uni4(GPA 3.8 > 3.5)
+        assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni3.id, uni5.id)
+    }
+
+    @Test
+    fun `GPA 3점5 + 어학 2개(OR 조건) 입력 시 하나라도 충족하면 포함된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?gpa=3.5&TOEFL_IBT=80&IELTS=5.0")
+
+        val ids = universityIds(response)
+        // uni1: TOEFL 80 충족(IELTS 6.0은 불충족이지만 OR이므로 포함)
+        // uni2: JLPT만 있어 TOEFL/IELTS 불충족 → 제외
+        assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni3.id, uni5.id)
+    }
+
+    // ── 전체 조회: 국가 + GPA + 어학 복합 필터 ─────────────────────────────
+
+    @Test
+    fun `나라 USA + GPA 3점5 + TOEFL IBT 80점 조합 시 조건 모두 충족하는 미국 대학만 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?nation=USA&gpa=3.5&TOEFL_IBT=80")
+
+        val ids = universityIds(response)
+        // USA: uni1, uni3 / GPA: uni1(3.0), uni3(2.5) / 어학: uni1 TOEFL 충족, uni3 없음
+        assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni3.id)
+    }
+
+    @Test
+    fun `나라 USA + GPA 3점5 + 어학 2개(OR) 조합 시 미국 대학 중 조건 충족 반환`() {
+        val response = get<Map<String, Any?>>("$baseUrl?nation=USA&gpa=3.5&TOEFL_IBT=80&IELTS=6.0")
+
+        val ids = universityIds(response)
+        assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni3.id)
+    }
+
+    @Test
+    fun `나라 JPN + GPA 4점0 + JLPT 2 조합 시 도쿄대가 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?nation=JPN&gpa=4.0&JLPT=2")
+
+        val ids = universityIds(response)
+        assertThat(ids).containsExactlyInAnyOrder(uni2.id)
+    }
+
+    // ── 전체 조회: JLPT 역방향 필터 ────────────────────────────────────────
+
+    @Test
+    fun `JLPT N1(레벨1) 보유 시 N2 요구 대학도 지원 가능하다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?JLPT=1")
+
+        val ids = universityIds(response)
+        // uni2: JLPT N2(minScore=2), DB:2 >= user:1 → 충족
+        assertThat(ids).contains(uni2.id)
+    }
+
+    @Test
+    fun `JLPT N3(레벨3) 보유 시 N2 요구 대학에 지원 불가능하다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?JLPT=3")
+
+        val ids = universityIds(response)
+        // uni2: DB:2 >= user:3 → false → 제외
+        assertThat(ids).doesNotContain(uni2.id)
+        assertThat(ids).containsExactlyInAnyOrder(uni3.id, uni5.id)
+    }
+
+    // ── 전체 조회: 기타 단독 필터 ──────────────────────────────────────────
+
+    @Test
+    fun `국가 USA 필터 시 미국 대학만 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?nation=USA")
+
+        val ids = universityIds(response)
+        assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni3.id)
+    }
+
+    @Test
+    fun `isExchange true 필터 시 일반교환 대학만 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?isExchange=true")
+
+        val ids = universityIds(response)
+        assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni2.id, uni4.id, uni5.id)
+        assertThat(ids).doesNotContain(uni3.id)
+    }
+
+    @Test
+    fun `isVisit true 필터 시 방문교환 대학만 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?isVisit=true")
+
+        val ids = universityIds(response)
+        assertThat(ids).containsExactlyInAnyOrder(uni3.id)
+    }
+
+    @Test
+    fun `hasReview true 필터 시 후기 있는 대학만 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?hasReview=true")
+
+        val ids = universityIds(response)
+        assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni4.id)
+    }
+
+    @Test
+    fun `search 키워드로 한국어 대학명 검색 시 해당 대학이 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?search=하버드")
+
+        val ids = universityIds(response)
+        assertThat(ids).containsExactlyInAnyOrder(uni1.id)
+    }
+
+    @Test
+    fun `search 키워드로 영어 대학명 검색 시 해당 대학이 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?search=Melbourne")
+
+        val ids = universityIds(response)
+        assertThat(ids).containsExactlyInAnyOrder(uni5.id)
+    }
+
+    @Test
+    fun `major 키워드로 수강 가능 학과 필터 시 해당 학과 포함 대학만 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?major=Business")
+
+        val ids = universityIds(response)
+        // uni1("Arts and Sciences, Business"), uni4("Business, Economics") 포함
+        assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni4.id)
+    }
+
+    // ── 전체 조회: 빈 결과 / 경계값 ────────────────────────────────────────
+
+    @Test
+    fun `일치하는 대학이 없으면 빈 리스트와 totalElements 0이 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?nation=DEU")
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        val result = result(response)
+        val universities = result["universities"] as List<*>
+        val pageInfo = result["pageInfo"] as Map<*, *>
+        assertThat(universities).isEmpty()
+        assertThat(pageInfo["totalElements"]).isEqualTo(0)
+    }
+
+    @Test
+    fun `페이지 크기 2로 요청 시 2개만 반환되고 pageInfo가 올바르게 계산된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?size=2&page=0")
+
+        val result = result(response)
+        val universities = result["universities"] as List<*>
+        val pageInfo = result["pageInfo"] as Map<*, *>
+        assertThat(universities).hasSize(2)
+        assertThat(pageInfo["totalElements"]).isEqualTo(5)
+        assertThat(pageInfo["isLast"]).isEqualTo(false)
+    }
+
+    @Test
+    fun `마지막 페이지에서는 isLast가 true로 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?size=3&page=1")
+
+        val result = result(response)
+        val pageInfo = result["pageInfo"] as Map<*, *>
+        assertThat(pageInfo["isLast"]).isEqualTo(true)
+    }
+
+    // ── 전체 조회: 어학 점수 유효 범위 초과 ────────────────────────────────
+
+    @Test
+    fun `TOEFL IBT 점수가 120 초과이면 400 에러가 반환된다`() {
+        val response = get<Map<String, Any?>>( "$baseUrl?TOEFL_IBT=999")
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+    }
+
+    @Test
+    fun `JLPT 레벨이 5 초과이면 400 에러가 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?JLPT=6")
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+    }
+
+    // ── 상세 조회: 정상 ─────────────────────────────────────────────────────
+
+    @Test
+    fun `존재하는 대학 ID로 상세 조회 시 올바른 데이터가 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl/${uni1.id}")
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        val detail = result(response)
+        assertThat(detail["nameKor"]).isEqualTo("하버드대학교")
+        assertThat(detail["programType"]).isEqualTo("일반교환")
+        assertThat(detail["location"]).isEqualTo("Cambridge, MA")
+        assertThat(detail["studentCount"]).isEqualTo("47,000")
+    }
+
+    @Test
+    fun `상세 조회 시 availableMajors가 콤마 기준으로 리스트로 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl/${uni1.id}")
+
+        val detail = result(response)
+        @Suppress("UNCHECKED_CAST")
+        val majors = detail["availableMajors"] as List<String>
+        assertThat(majors).containsExactlyInAnyOrder("Arts and Sciences", "Business")
+    }
+
+    @Test
+    fun `상세 조회 시 courseListUrl은 availableSubject 필드 값이다`() {
+        val url = "https://example.com/courses"
+        val saved = universityJpaRepository.save(makeUniversity(
+            nameKor = "URL테스트대학", nameEng = "URL Test University",
+            availableSubject = url
+        ))
+
+        val response = get<Map<String, Any?>>("$baseUrl/${saved.id}")
+
+        val detail = result(response)
+        assertThat(detail["courseListUrl"]).isEqualTo(url)
+    }
+
+    @Test
+    fun `방문교환 대학 상세 조회 시 programType이 방문교환이다`() {
+        val response = get<Map<String, Any?>>("$baseUrl/${uni3.id}")
+
+        val detail = result(response)
+        assertThat(detail["programType"]).isEqualTo("방문교환")
+    }
+
+    @Test
+    fun `어학 요구사항이 있는 대학 상세 조회 시 languageRequirements에 해당 정보가 포함된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl/${uni1.id}")
+
+        val detail = result(response)
+        @Suppress("UNCHECKED_CAST")
+        val langReqs = detail["languageRequirements"] as List<Map<String, Any?>>
+        assertThat(langReqs).hasSize(2)
+        val examTypes = langReqs.map { it["examType"] }
+        assertThat(examTypes).containsExactlyInAnyOrder("TOEFL iBT", "IELTS")
+    }
+
+    @Test
+    fun `어학 요구사항이 없는 대학 상세 조회 시 languageRequirements가 빈 리스트다`() {
+        val response = get<Map<String, Any?>>("$baseUrl/${uni5.id}")
+
+        val detail = result(response)
+        @Suppress("UNCHECKED_CAST")
+        val langReqs = detail["languageRequirements"] as List<*>
+        assertThat(langReqs).isEmpty()
+    }
+
+    // ── 상세 조회: 에러 ─────────────────────────────────────────────────────
+
+    @Test
+    fun `존재하지 않는 대학 ID로 상세 조회 시 404가 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl/999999")
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        val body = response.body!!
+        assertThat(body["code"]).isEqualTo("U404_001")
+    }
+
+    @Test
+    fun `존재하지 않는 엔드포인트 호출 시 404가 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl/999999/unknown")
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    // ── 헬퍼 ────────────────────────────────────────────────────────────────
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> get(url: String) =
+        restTemplate.getForEntity(url, Map::class.java) as org.springframework.http.ResponseEntity<Map<String, Any?>>
+
+    @Suppress("UNCHECKED_CAST")
+    private fun result(response: org.springframework.http.ResponseEntity<Map<String, Any?>>) =
+        response.body!!["result"] as Map<String, Any?>
+
+    @Suppress("UNCHECKED_CAST")
+    private fun universities(response: org.springframework.http.ResponseEntity<Map<String, Any?>>) =
+        (result(response)["universities"] as List<Map<String, Any?>>)
+
+    private fun universityIds(response: org.springframework.http.ResponseEntity<Map<String, Any?>>): List<Long> {
+        return universities(response).map { (it["id"] as Number).toLong() }
+    }
+
+    private fun makeUniversity(
+        nameKor: String = "테스트대학",
+        nameEng: String = "Test University",
+        nation: String = "USA",
+        minGpa: Double = 3.0,
+        isExchange: Boolean = true,
+        isVisit: Boolean = false,
+        hasReview: Boolean = false,
+        reviewYear: String? = null,
+        availableMajor: String? = null,
+        availableSubject: String? = null,
+        location: String? = null,
+        studentCount: String? = null
+    ) = UniversityEntity(
+        semester = "2024-1",
+        region = "미주",
+        nation = nation,
+        nameKor = nameKor,
+        nameEng = nameEng,
+        minGpa = minGpa,
+        remark = "특이사항 없음",
+        isExchange = isExchange,
+        isVisit = isVisit,
+        hasReview = hasReview,
+        reviewYear = reviewYear,
+        availableMajor = availableMajor,
+        availableSubject = availableSubject,
+        location = location,
+        studentCount = studentCount
+    )
+
+    private fun makeLangReq(
+        universityId: Long,
+        languageGroup: String,
+        examType: String,
+        minScore: Double,
+        levelCode: String? = null
+    ) = LanguageRequirementEntity(
+        universityId = universityId,
+        languageGroup = languageGroup,
+        examType = examType,
+        minScore = minScore,
+        levelCode = levelCode
+    )
+}

--- a/src/test/kotlin/org/example/beyondubackend/domain/university/unit/LanguageRequirementSummaryTest.kt
+++ b/src/test/kotlin/org/example/beyondubackend/domain/university/unit/LanguageRequirementSummaryTest.kt
@@ -1,0 +1,107 @@
+package org.example.beyondubackend.domain.university.unit
+
+import org.assertj.core.api.Assertions.assertThat
+import org.example.beyondubackend.domain.languagerequirement.implement.LanguageRequirement
+import org.example.beyondubackend.domain.languagerequirement.implement.LanguageRequirementReader
+import org.example.beyondubackend.domain.languagerequirement.implement.LanguageRequirementRepository
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class LanguageRequirementSummaryTest {
+
+    @Mock
+    private lateinit var languageRequirementRepository: LanguageRequirementRepository
+
+    @InjectMocks
+    private lateinit var reader: LanguageRequirementReader
+
+    // ── generateSummary ─────────────────────────────────────────────────────
+
+    @Test
+    fun `빈 리스트이면 null을 반환한다`() {
+        val result = reader.generateSummary(emptyList())
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `단일 TOEFL iBT 요구사항은 점수가 정수이면 정수 형태로 표시된다`() {
+        val requirements = listOf(req("TOEFL iBT", 100.0))
+
+        val result = reader.generateSummary(requirements)
+
+        assertThat(result).isEqualTo("TOEFL iBT 100")
+    }
+
+    @Test
+    fun `점수가 소수이면 소수점까지 그대로 표시된다`() {
+        val requirements = listOf(req("IELTS", 6.5))
+
+        val result = reader.generateSummary(requirements)
+
+        assertThat(result).isEqualTo("IELTS 6.5")
+    }
+
+    @Test
+    fun `복수 요구사항은 슬래시로 구분하여 모두 표시된다`() {
+        val requirements = listOf(
+            req("TOEFL iBT", 100.0),
+            req("IELTS", 7.0)
+        )
+
+        val result = reader.generateSummary(requirements)
+
+        // 소수점이 0이면 정수로 포맷(7.0 → "7")
+        assertThat(result).isEqualTo("TOEFL iBT 100 / IELTS 7")
+    }
+
+    @Test
+    fun `HSK는 levelCode와 무관하게 suffix(급)가 붙어서 표시된다`() {
+        val requirements = listOf(req("HSK", 4.0))
+
+        val result = reader.generateSummary(requirements)
+
+        assertThat(result).isEqualTo("HSK 4급")
+    }
+
+    @Test
+    fun `JLPT는 prefix N이 붙어서 표시된다`() {
+        val requirements = listOf(req("JLPT", 2.0))
+
+        val result = reader.generateSummary(requirements)
+
+        assertThat(result).isEqualTo("JLPT N2")
+    }
+
+    @Test
+    fun `세 개 이상 요구사항도 슬래시로 올바르게 연결된다`() {
+        val requirements = listOf(
+            req("TOEFL iBT", 80.0),
+            req("TOEIC", 700.0),
+            req("IELTS", 6.0)
+        )
+
+        val result = reader.generateSummary(requirements)
+
+        // 소수점이 0이면 정수로 포맷(6.0 → "6")
+        assertThat(result).isEqualTo("TOEFL iBT 80 / TOEIC 700 / IELTS 6")
+    }
+
+    // ── 헬퍼 ────────────────────────────────────────────────────────────────
+
+    private fun req(
+        examType: String,
+        minScore: Double,
+        levelCode: String? = null
+    ) = LanguageRequirement(
+        universityId = 1L,
+        languageGroup = "영어",
+        examType = examType,
+        minScore = minScore,
+        levelCode = levelCode
+    )
+}

--- a/src/test/kotlin/org/example/beyondubackend/domain/university/unit/UniversityDetailResponseTest.kt
+++ b/src/test/kotlin/org/example/beyondubackend/domain/university/unit/UniversityDetailResponseTest.kt
@@ -1,0 +1,187 @@
+package org.example.beyondubackend.domain.university.unit
+
+import org.assertj.core.api.Assertions.assertThat
+import org.example.beyondubackend.domain.university.business.dto.LanguageRequirementResponse
+import org.example.beyondubackend.domain.university.business.dto.UniversityDetailResponse
+import org.example.beyondubackend.domain.university.implement.University
+import org.junit.jupiter.api.Test
+
+class UniversityDetailResponseTest {
+
+    // ── availableMajors 파싱 (availableMajor DB 필드 → 콤마 분리 리스트) ───
+
+    @Test
+    fun `availableMajor 콤마 구분 문자열은 트림된 리스트로 변환된다`() {
+        val university = makeUniversity(availableMajor = "Arts and Sciences, Business, Engineering")
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        assertThat(result.availableMajors).containsExactly("Arts and Sciences", "Business", "Engineering")
+    }
+
+    @Test
+    fun `availableMajor 항목 주변의 공백이 제거된다`() {
+        val university = makeUniversity(availableMajor = "  Arts and Sciences  ,  Business  ")
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        assertThat(result.availableMajors).containsExactly("Arts and Sciences", "Business")
+    }
+
+    @Test
+    fun `availableMajor가 null이면 availableMajors가 null로 반환된다`() {
+        val university = makeUniversity(availableMajor = null)
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        assertThat(result.availableMajors).isNull()
+    }
+
+    @Test
+    fun `availableMajor가 공백과 콤마만 있으면 null로 반환된다`() {
+        val university = makeUniversity(availableMajor = "  ,  ,  ")
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        assertThat(result.availableMajors).isNull()
+    }
+
+    @Test
+    fun `availableMajor가 단일 항목이면 단일 원소 리스트로 반환된다`() {
+        val university = makeUniversity(availableMajor = "Engineering")
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        assertThat(result.availableMajors).containsExactly("Engineering")
+    }
+
+    // ── courseListUrl (availableSubject DB 필드 직접 매핑) ──────────────────
+
+    @Test
+    fun `availableSubject URL이 courseListUrl로 그대로 반환된다`() {
+        val url = "https://example.edu/courses"
+        val university = makeUniversity(availableSubject = url)
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        assertThat(result.courseListUrl).isEqualTo(url)
+    }
+
+    @Test
+    fun `availableSubject가 null이면 courseListUrl도 null이다`() {
+        val university = makeUniversity(availableSubject = null)
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        assertThat(result.courseListUrl).isNull()
+    }
+
+    // ── programType 규칙 ────────────────────────────────────────────────────
+
+    @Test
+    fun `isExchange true이면 programType이 일반교환이다`() {
+        val university = makeUniversity(isExchange = true, isVisit = false)
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        assertThat(result.programType).isEqualTo("일반교환")
+    }
+
+    @Test
+    fun `isVisit true이면 programType이 방문교환이다`() {
+        val university = makeUniversity(isExchange = false, isVisit = true)
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        assertThat(result.programType).isEqualTo("방문교환")
+    }
+
+    @Test
+    fun `isExchange와 isVisit 모두 false이면 programType이 빈 문자열이다`() {
+        val university = makeUniversity(isExchange = false, isVisit = false)
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        assertThat(result.programType).isEqualTo("")
+    }
+
+    // ── location / studentCount 직접 매핑 ──────────────────────────────────
+
+    @Test
+    fun `location DB 필드가 location으로 그대로 반환된다`() {
+        val university = makeUniversity(location = "Cambridge, MA")
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        assertThat(result.location).isEqualTo("Cambridge, MA")
+    }
+
+    @Test
+    fun `location이 null이면 location도 null이다`() {
+        val university = makeUniversity(location = null)
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        assertThat(result.location).isNull()
+    }
+
+    @Test
+    fun `studentCount DB 필드가 studentCount로 그대로 반환된다`() {
+        val university = makeUniversity(studentCount = "47,000")
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        assertThat(result.studentCount).isEqualTo("47,000")
+    }
+
+    @Test
+    fun `studentCount가 null이면 null로 반환된다`() {
+        val university = makeUniversity(studentCount = null)
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        assertThat(result.studentCount).isNull()
+    }
+
+    // ── languageRequirements 전달 ────────────────────────────────────────────
+
+    @Test
+    fun `전달된 languageRequirements 리스트가 그대로 포함된다`() {
+        val university = makeUniversity()
+        val langReqs = listOf(
+            LanguageRequirementResponse(languageGroup = "영어", examType = "TOEFL iBT", minScore = 80.0)
+        )
+
+        val result = UniversityDetailResponse.from(university, langReqs)
+
+        assertThat(result.languageRequirements).hasSize(1)
+        assertThat(result.languageRequirements[0].examType).isEqualTo("TOEFL iBT")
+    }
+
+    // ── 헬퍼 ────────────────────────────────────────────────────────────────
+
+    private fun makeUniversity(
+        id: Long = 1L,
+        isExchange: Boolean = true,
+        isVisit: Boolean = false,
+        availableMajor: String? = null,
+        availableSubject: String? = null,
+        location: String? = null,
+        studentCount: String? = null
+    ) = University(
+        id = id,
+        semester = "2024-1",
+        region = "미주",
+        nation = "USA",
+        nameKor = "테스트대학교",
+        nameEng = "Test University",
+        minGpa = 3.0,
+        remark = "특이사항 없음",
+        isExchange = isExchange,
+        isVisit = isVisit,
+        availableMajor = availableMajor,
+        availableSubject = availableSubject,
+        location = location,
+        studentCount = studentCount
+    )
+}

--- a/src/test/kotlin/org/example/beyondubackend/domain/university/unit/UniversityReaderTest.kt
+++ b/src/test/kotlin/org/example/beyondubackend/domain/university/unit/UniversityReaderTest.kt
@@ -1,0 +1,58 @@
+package org.example.beyondubackend.domain.university.unit
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.example.beyondubackend.common.code.ErrorCode
+import org.example.beyondubackend.common.exception.BusinessException
+import org.example.beyondubackend.domain.languagerequirement.storage.LanguageRequirementJpaRepository
+import org.example.beyondubackend.domain.university.implement.UniversityReader
+import org.example.beyondubackend.domain.university.implement.UniversityRepository
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class UniversityReaderTest {
+
+    @Mock
+    private lateinit var universityRepository: UniversityRepository
+
+    @Mock
+    private lateinit var languageRequirementJpaRepository: LanguageRequirementJpaRepository
+
+    @InjectMocks
+    private lateinit var universityReader: UniversityReader
+
+    @Test
+    fun `존재하지 않는 ID로 조회 시 UNIVERSITY_NOT_FOUND BusinessException이 발생한다`() {
+        given(universityRepository.findById(999L)).willReturn(null)
+
+        assertThatThrownBy { universityReader.getUniversityById(999L) }
+            .isInstanceOf(BusinessException::class.java)
+            .hasMessageContaining(ErrorCode.UNIVERSITY_NOT_FOUND.message)
+    }
+
+    @Test
+    fun `존재하는 ID로 조회 시 University 도메인 객체가 반환된다`() {
+        val university = org.example.beyondubackend.domain.university.implement.University(
+            id = 1L,
+            semester = "2024-1",
+            region = "미주",
+            nation = "USA",
+            nameKor = "하버드대학교",
+            nameEng = "Harvard University",
+            minGpa = 3.0,
+            remark = "특이사항 없음",
+            isExchange = true,
+            isVisit = false
+        )
+        given(universityRepository.findById(1L)).willReturn(university)
+
+        val result = universityReader.getUniversityById(1L)
+
+        org.assertj.core.api.Assertions.assertThat(result.id).isEqualTo(1L)
+        org.assertj.core.api.Assertions.assertThat(result.nameKor).isEqualTo("하버드대학교")
+    }
+}


### PR DESCRIPTION
closes #35, #34 

---

## 핵심 변경 사항

이번 PR의 핵심은 **정규화된 DB 스키마 기준으로 매핑 전환**과 **AOP 기반 로깅 전략 구현**입니다.

### DB 스키마 변경 대응
- `available_majors` (텍스트 파싱) → `available_major` + `available_subject` (DB 컬럼 직접 매핑)
- `remark` (텍스트 파싱) → `location` + `student_count` (DB 컬럼 직접 매핑)
- `is_available` 필드 제거 — `language_requirement` 전체 레코드가 유효 데이터

### 어학 성적 표시 개선
- `ExamType` enum에 `prefix` / `suffix` 추가
- **JLPT**: 숫자 앞에 `N` 붙음 → `JLPT N2`
- **HSK**: 숫자 뒤에 `급` 붙음 → `HSK 4급`

### 아키텍처 위반 수정
- `UniversityReader`가 `LanguageRequirementJpaRepository`를 직접 참조하던 구조 제거
- `UniversityServiceImpl`에서 `LanguageRequirementReader`를 통해 접근하도록 수정

### AOP 로깅
- `TraceIdFilter` → MDC `traceId` 주입
- `@Loggable` + `LoggingAspect` → `[IN] args`, `[OUT] elapsed`, `[ERR]` 자동 출력
- `logback-spring.xml` → local 컬러 패턴 / prod JSON

---

## 실행 예시

### GET /api/v1/universities?JLPT=2&HSK=4

```json
// 응답 (목록)
{
  "success": true,
  "data": {
    "universities": [
      {
        "id": 3,
        "nameKor": "도쿄대학교",
        "nameEng": "University of Tokyo",
        "nation": "JPN",
        "minGpa": 3.0,
        "languageRequirementSummary": "JLPT N2"
      },
      {
        "id": 7,
        "nameKor": "베이징대학교",
        "nameEng": "Peking University",
        "nation": "CHN",
        "minGpa": 3.2,
        "languageRequirementSummary": "HSK 4급"
      }
    ]
  }
}
```

### GET /api/v1/universities/{id} — 상세 (정규화 필드 직접 매핑)

```json
// 응답 (상세)
{
  "success": true,
  "data": {
    "id": 3,
    "nameKor": "도쿄대학교",
    "nameEng": "University of Tokyo",
    "nation": "JPN",
    "programType": "일반교환",
    "minGpa": 3.0,
    "location": "Tokyo, Japan",
    "studentCount": "약 28,000 명",
    "availableMajors": ["Engineering", "Liberal Arts"],
    "courseListUrl": "https://www.u-tokyo.ac.jp/courses",
    "languageRequirements": [
      {
        "languageGroup": "일본어",
        "examType": "JLPT",
        "minScore": 2.0
      }
    ]
  }
}
```

### 로그 출력 (local)
```
10:23:41.123 [a1b2-c3d4] INFO  UniversityServiceImpl - [IN]  getUniversities args=[UniversityQuery(...)]
10:23:41.156 [a1b2-c3d4] INFO  UniversityServiceImpl - [OUT] getUniversities elapsed=33ms
10:23:41.200 [a1b2-c3d4] WARN  ClientExceptionHandler - BusinessException: UNIVERSITY_NOT_FOUND
```

### 로그 출력 (prod, JSON)
```json
{"timestamp":"2025-03-29T10:23:41.123Z","level":"INFO","traceId":"a1b2-c3d4","logger":"UniversityServiceImpl","message":"[IN]  getUniversities args=[UniversityQuery(...)]"}
{"timestamp":"2025-03-29T10:23:41.156Z","level":"INFO","traceId":"a1b2-c3d4","logger":"UniversityServiceImpl","message":"[OUT] getUniversities elapsed=33ms"}
```

---

## 참고사항

- `levelCode` DB 값(A3, CN_B3 등)은 내부 분류 코드 — 표시용 prefix/suffix는 `ExamType` enum에서 하드코딩 관리
- `BusinessException`은 AOP 대신 `ClientExceptionHandler`에서 WARN 처리 (이중 로깅 방지)