### PR TITLE
[#37] feat: university region 필터링 및 nations 복수 OR 조건 검색 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
-	kotlin("jvm") version "2.2.21"
-	kotlin("plugin.spring") version "2.2.21"
-	id("org.springframework.boot") version "3.4.1"
-	id("io.spring.dependency-management") version "1.1.7"
-	kotlin("plugin.jpa") version "2.2.21"
-	kotlin("kapt") version "2.2.21"
+    kotlin("jvm") version "2.2.21"
+    kotlin("plugin.spring") version "2.2.21"
+    id("org.springframework.boot") version "3.4.1"
+    id("io.spring.dependency-management") version "1.1.7"
+    kotlin("plugin.jpa") version "2.2.21"
+    kotlin("kapt") version "2.2.21"
 }
 
 group = "org.example"
@@ -12,13 +12,13 @@ version = "0.0.1-SNAPSHOT"
 description = "BeyondU-backend"
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
@@ -33,8 +33,8 @@ dependencies {
     kapt("jakarta.annotation:jakarta.annotation-api")
     kapt("jakarta.persistence:jakarta.persistence-api")
 
-	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13")
-	implementation("net.logstash.logback:logstash-logback-encoder:8.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13")
+    implementation("net.logstash.logback:logstash-logback-encoder:8.0")
 
     runtimeOnly("com.mysql:mysql-connector-j")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
@@ -44,21 +44,21 @@ dependencies {
 }
 
 kotlin {
-	compilerOptions {
-		freeCompilerArgs.addAll("-Xjsr305=strict", "-Xannotation-default-target=param-property")
-	}
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xjsr305=strict", "-Xannotation-default-target=param-property")
+    }
 }
 
 allOpen {
-	annotation("jakarta.persistence.Entity")
-	annotation("jakarta.persistence.MappedSuperclass")
-	annotation("jakarta.persistence.Embeddable")
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.MappedSuperclass")
+    annotation("jakarta.persistence.Embeddable")
 }
 
 kotlin.sourceSets.main {
-	kotlin.srcDir("build/generated/source/kapt/main")
+    kotlin.srcDir("build/generated/source/kapt/main")
 }
 
 tasks.withType<Test> {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/kotlin/org/example/beyondubackend/BeyondUBackendApplication.kt
+++ b/src/main/kotlin/org/example/beyondubackend/BeyondUBackendApplication.kt
@@ -7,5 +7,5 @@ import org.springframework.boot.runApplication
 class BeyondUBackendApplication
 
 fun main(args: Array<String>) {
-	runApplication<BeyondUBackendApplication>(*args)
+    runApplication<BeyondUBackendApplication>(*args)
 }

--- a/src/main/kotlin/org/example/beyondubackend/common/annotation/Loggable.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/annotation/Loggable.kt
@@ -3,7 +3,7 @@ package org.example.beyondubackend.common.annotation
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Loggable(
-    val level: LogLevel = LogLevel.INFO
+    val level: LogLevel = LogLevel.INFO,
 )
 
 enum class LogLevel { INFO, DEBUG }

--- a/src/main/kotlin/org/example/beyondubackend/common/code/ErrorCode.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/code/ErrorCode.kt
@@ -2,7 +2,11 @@ package org.example.beyondubackend.common.code
 
 import org.springframework.http.HttpStatus
 
-enum class ErrorCode(val code: String, val httpStatus: HttpStatus, val message: String) {
+enum class ErrorCode(
+    val code: String,
+    val httpStatus: HttpStatus,
+    val message: String,
+) {
     // COMMON
     INVALID_INPUT("C400_001", HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
     BAD_REQUEST("C400_002", HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
@@ -18,5 +22,5 @@ enum class ErrorCode(val code: String, val httpStatus: HttpStatus, val message: 
     UNIVERSITY_NOT_FOUND("U404_001", HttpStatus.NOT_FOUND, "대학교를 찾을 수 없습니다."),
 
     // LANGUAGE REQUIREMENT
-    INVALID_EXAM_SCORE("L400_001", HttpStatus.BAD_REQUEST, "어학 점수가 유효 범위를 벗어났습니다.")
+    INVALID_EXAM_SCORE("L400_001", HttpStatus.BAD_REQUEST, "어학 점수가 유효 범위를 벗어났습니다."),
 }

--- a/src/main/kotlin/org/example/beyondubackend/common/code/SuccessCode.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/code/SuccessCode.kt
@@ -3,7 +3,11 @@ package org.example.beyondubackend.common.code
 
 import org.springframework.http.HttpStatus
 
-enum class SuccessCode(val code: String, val httpStatus: HttpStatus, val message: String) {
+enum class SuccessCode(
+    val code: String,
+    val httpStatus: HttpStatus,
+    val message: String,
+) {
     OK("S001", HttpStatus.OK, "요청 성공"),
-    CREATED("S002", HttpStatus.CREATED, "생성 성공");
+    CREATED("S002", HttpStatus.CREATED, "생성 성공"),
 }

--- a/src/main/kotlin/org/example/beyondubackend/common/config/LoggingAspect.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/config/LoggingAspect.kt
@@ -14,19 +14,19 @@ import org.springframework.stereotype.Component
 @Aspect
 @Component
 class LoggingAspect {
-
     @Around(
         "@within(org.example.beyondubackend.common.annotation.Loggable) || " +
-        "@annotation(org.example.beyondubackend.common.annotation.Loggable)"
+            "@annotation(org.example.beyondubackend.common.annotation.Loggable)",
     )
     fun log(joinPoint: ProceedingJoinPoint): Any? {
         val signature = joinPoint.signature as MethodSignature
         val method = signature.method
         val targetClass = joinPoint.target.javaClass
 
-        val loggable = method.getAnnotation(Loggable::class.java)
-            ?: targetClass.getAnnotation(Loggable::class.java)
-            ?: return joinPoint.proceed()
+        val loggable =
+            method.getAnnotation(Loggable::class.java)
+                ?: targetClass.getAnnotation(Loggable::class.java)
+                ?: return joinPoint.proceed()
 
         val logger = LoggerFactory.getLogger(targetClass)
         val methodName = "${targetClass.simpleName}.${method.name}"
@@ -50,15 +50,23 @@ class LoggingAspect {
         }
     }
 
-    private fun buildArgString(joinPoint: ProceedingJoinPoint, signature: MethodSignature): String {
+    private fun buildArgString(
+        joinPoint: ProceedingJoinPoint,
+        signature: MethodSignature,
+    ): String {
         val params = signature.method.parameters
-        return joinPoint.args.mapIndexed { i, arg ->
-            val isMasked = params.getOrNull(i)?.isAnnotationPresent(LogMask::class.java) == true
-            if (isMasked) "****" else arg
-        }.toString()
+        return joinPoint.args
+            .mapIndexed { i, arg ->
+                val isMasked = params.getOrNull(i)?.isAnnotationPresent(LogMask::class.java) == true
+                if (isMasked) "****" else arg
+            }.toString()
     }
 
-    private fun logAt(logger: org.slf4j.Logger, level: LogLevel, message: String) {
+    private fun logAt(
+        logger: org.slf4j.Logger,
+        level: LogLevel,
+        message: String,
+    ) {
         when (level) {
             LogLevel.INFO -> logger.info(message)
             LogLevel.DEBUG -> logger.debug(message)

--- a/src/main/kotlin/org/example/beyondubackend/common/config/QueryDslConfig.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/config/QueryDslConfig.kt
@@ -8,12 +8,9 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 class QueryDslConfig {
-
     @PersistenceContext
     private lateinit var entityManager: EntityManager
 
     @Bean
-    fun jpaQueryFactory(): JPAQueryFactory {
-        return JPAQueryFactory(entityManager)
-    }
+    fun jpaQueryFactory(): JPAQueryFactory = JPAQueryFactory(entityManager)
 }

--- a/src/main/kotlin/org/example/beyondubackend/common/config/SwaggerConfig.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/config/SwaggerConfig.kt
@@ -8,20 +8,17 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 class SwaggerConfig {
-
     @Bean
-    fun openAPI(): OpenAPI {
-        return OpenAPI()
+    fun openAPI(): OpenAPI =
+        OpenAPI()
             .info(
                 Info()
                     .title("Beyond-U API")
                     .version("v1.0.0")
-                    .description("교환학생 준비 관리 플랫폼 API 문서")
-            )
-            .servers(
+                    .description("교환학생 준비 관리 플랫폼 API 문서"),
+            ).servers(
                 listOf(
-                    Server().url("/").description("Current Server")
-                )
+                    Server().url("/").description("Current Server"),
+                ),
             )
-    }
 }

--- a/src/main/kotlin/org/example/beyondubackend/common/config/WebMvcConfig.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/config/WebMvcConfig.kt
@@ -7,7 +7,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 class WebMvcConfig : WebMvcConfigurer {
-
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
         resolvers.add(ExamScoreArgumentResolver())
     }

--- a/src/main/kotlin/org/example/beyondubackend/common/dto/ApiResponse.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/dto/ApiResponse.kt
@@ -9,25 +9,37 @@ import org.springframework.http.ResponseEntity
 data class ApiResponse<T>(
     val code: String,
     val message: String,
-    val result: T? = null
+    val result: T? = null,
 ) {
     companion object {
         fun <T> success(result: T): ResponseEntity<ApiResponse<T>> =
-            ResponseEntity.ok(ApiResponse(
-                code = SuccessCode.OK.code,
-                message = SuccessCode.OK.message,
-                result = result
-            ))
+            ResponseEntity.ok(
+                ApiResponse(
+                    code = SuccessCode.OK.code,
+                    message = SuccessCode.OK.message,
+                    result = result,
+                ),
+            )
 
-        fun <T> success(successCode: SuccessCode, result: T? = null): ResponseEntity<ApiResponse<T>> =
-            ResponseEntity.status(successCode.httpStatus)
+        fun <T> success(
+            successCode: SuccessCode,
+            result: T? = null,
+        ): ResponseEntity<ApiResponse<T>> =
+            ResponseEntity
+                .status(successCode.httpStatus)
                 .body(ApiResponse(successCode.code, successCode.message, result))
 
-        fun fail(errorCode: ErrorCode, message: String? = null): ResponseEntity<ApiResponse<Unit>> =
-            ResponseEntity.status(errorCode.httpStatus)
-                .body(ApiResponse(
-                    code = errorCode.code,
-                    message = message ?: errorCode.message
-                ))
+        fun fail(
+            errorCode: ErrorCode,
+            message: String? = null,
+        ): ResponseEntity<ApiResponse<Unit>> =
+            ResponseEntity
+                .status(errorCode.httpStatus)
+                .body(
+                    ApiResponse(
+                        code = errorCode.code,
+                        message = message ?: errorCode.message,
+                    ),
+                )
     }
 }

--- a/src/main/kotlin/org/example/beyondubackend/common/dto/PageInfo.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/dto/PageInfo.kt
@@ -4,5 +4,5 @@ data class PageInfo(
     val currentPage: Int,
     val totalElements: Long,
     val totalPages: Int,
-    val isLast: Boolean
+    val isLast: Boolean,
 )

--- a/src/main/kotlin/org/example/beyondubackend/common/enums/ExamType.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/enums/ExamType.kt
@@ -6,7 +6,7 @@ enum class ExamType(
     val minScore: Double,
     val maxScore: Double,
     val prefix: String = "",
-    val suffix: String = ""
+    val suffix: String = "",
 ) {
     TOEFL_IBT("TOEFL_IBT", "TOEFL iBT", 0.0, 120.0),
     TOEFL_ITP("TOEFL_ITP", "TOEFL ITP", 0.0, 677.0),
@@ -17,10 +17,12 @@ enum class ExamType(
     JLPT("JLPT", "JLPT", 1.0, 5.0, prefix = "N"),
     JPT("JPT", "JPT", 0.0, 990.0),
     DELF("DELF", "DELF", 1.0, 6.0),
-    ZD("ZD", "ZD", 1.0, 6.0);
+    ZD("ZD", "ZD", 1.0, 6.0),
+    ;
 
     companion object {
         fun fromParamName(paramName: String): ExamType? = entries.find { it.paramName == paramName }
+
         fun fromDisplayName(displayName: String): ExamType? = entries.find { it.displayName == displayName }
     }
 }

--- a/src/main/kotlin/org/example/beyondubackend/common/enums/Nation.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/enums/Nation.kt
@@ -1,6 +1,8 @@
 package org.example.beyondubackend.common.enums
 
-enum class Nation(val displayName: String) {
+enum class Nation(
+    val displayName: String,
+) {
     GUATEMALA("과테말라"),
     GREECE("그리스"),
     NETHERLANDS("네덜란드"),
@@ -59,7 +61,8 @@ enum class Nation(val displayName: String) {
     PHILIPPINES("필리핀"),
     HUNGARY("헝가리"),
     AUSTRALIA("호주"),
-    HONG_KONG("홍콩");
+    HONG_KONG("홍콩"),
+    ;
 
     companion object {
         fun fromDisplayName(name: String): Nation? = entries.find { it.displayName == name }

--- a/src/main/kotlin/org/example/beyondubackend/common/enums/Region.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/enums/Region.kt
@@ -1,0 +1,14 @@
+package org.example.beyondubackend.common.enums
+
+enum class Region(val displayName: String) {
+    EUROPE("유럽"),
+    ASIA("아시아"),
+    NORTH_AMERICA("북미"),
+    SOUTH_AMERICA("남미"),
+    OCEANIA("오세아니아"),
+    AFRICA("아프리카");
+
+    companion object {
+        fun fromDisplayName(name: String): Region? = entries.find { it.displayName == name }
+    }
+}

--- a/src/main/kotlin/org/example/beyondubackend/common/enums/Region.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/enums/Region.kt
@@ -1,12 +1,15 @@
 package org.example.beyondubackend.common.enums
 
-enum class Region(val displayName: String) {
+enum class Region(
+    val displayName: String,
+) {
     EUROPE("유럽"),
     ASIA("아시아"),
     NORTH_AMERICA("북미"),
     SOUTH_AMERICA("남미"),
     OCEANIA("오세아니아"),
-    AFRICA("아프리카");
+    AFRICA("아프리카"),
+    ;
 
     companion object {
         fun fromDisplayName(name: String): Region? = entries.find { it.displayName == name }

--- a/src/main/kotlin/org/example/beyondubackend/common/exception/BusinessException.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/exception/BusinessException.kt
@@ -4,5 +4,5 @@ import org.example.beyondubackend.common.code.ErrorCode
 
 open class BusinessException(
     val errorCode: ErrorCode,
-    message: String = errorCode.message
+    message: String = errorCode.message,
 ) : RuntimeException(message)

--- a/src/main/kotlin/org/example/beyondubackend/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/exception/GlobalExceptionHandler.kt
@@ -11,44 +11,38 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.servlet.resource.NoResourceFoundException
 
-
 @RestControllerAdvice
 class ClientExceptionHandler {
-
     // BusinessException 처리
     @ExceptionHandler(BusinessException::class)
-    fun handleBusinessException(e: BusinessException): ResponseEntity<ApiResponse<Unit>> {
-        return ApiResponse.fail(e.errorCode, e.message)
-    }
+    fun handleBusinessException(e: BusinessException): ResponseEntity<ApiResponse<Unit>> = ApiResponse.fail(e.errorCode, e.message)
 
     // @Valid 유효성 검사 실패
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleValidationException(e: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Unit>> {
-        val errorMessage = e.bindingResult.fieldErrors.firstOrNull()?.defaultMessage
+        val errorMessage =
+            e.bindingResult.fieldErrors
+                .firstOrNull()
+                ?.defaultMessage
         return ApiResponse.fail(ErrorCode.INVALID_INPUT, errorMessage)
     }
 
     // 404: 존재하지 않는 API 경로
     @ExceptionHandler(NoResourceFoundException::class)
-    fun handleNoResource(e: NoResourceFoundException): ResponseEntity<ApiResponse<Unit>> {
-        return ApiResponse.fail(ErrorCode.ENDPOINT_NOT_FOUND)
-    }
+    fun handleNoResource(e: NoResourceFoundException): ResponseEntity<ApiResponse<Unit>> = ApiResponse.fail(ErrorCode.ENDPOINT_NOT_FOUND)
 
     // 405: 지원하지 않는 HTTP 메서드 호출
     @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
-    fun handleMethodNotSupported(e: HttpRequestMethodNotSupportedException): ResponseEntity<ApiResponse<Unit>> {
-        return ApiResponse.fail(ErrorCode.METHOD_NOT_ALLOWED)
-    }
+    fun handleMethodNotSupported(e: HttpRequestMethodNotSupportedException): ResponseEntity<ApiResponse<Unit>> =
+        ApiResponse.fail(ErrorCode.METHOD_NOT_ALLOWED)
 
     // 타입 불일치 (Path Variable이나 Query Param 타입 오류)
     @ExceptionHandler(MethodArgumentTypeMismatchException::class)
-    fun handleTypeMismatch(e: MethodArgumentTypeMismatchException): ResponseEntity<ApiResponse<Unit>> {
-        return ApiResponse.fail(ErrorCode.BAD_REQUEST, "파라미터 타입이 올바르지 않습니다.")
-    }
+    fun handleTypeMismatch(e: MethodArgumentTypeMismatchException): ResponseEntity<ApiResponse<Unit>> =
+        ApiResponse.fail(ErrorCode.BAD_REQUEST, "파라미터 타입이 올바르지 않습니다.")
 
     // JSON 파싱 에러 (Body 데이터 형식 오류)
     @ExceptionHandler(HttpMessageNotReadableException::class)
-    fun handleJsonError(e: HttpMessageNotReadableException): ResponseEntity<ApiResponse<Unit>> {
-        return ApiResponse.fail(ErrorCode.BAD_REQUEST, "잘못된 JSON 형식입니다.")
-    }
+    fun handleJsonError(e: HttpMessageNotReadableException): ResponseEntity<ApiResponse<Unit>> =
+        ApiResponse.fail(ErrorCode.BAD_REQUEST, "잘못된 JSON 형식입니다.")
 }

--- a/src/main/kotlin/org/example/beyondubackend/common/exception/InternalServerErrorHandler.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/exception/InternalServerErrorHandler.kt
@@ -8,10 +8,8 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
-
 @RestControllerAdvice
 class ServerExceptionHandler {
-
     private val logger = LoggerFactory.getLogger(ServerExceptionHandler::class.java)
 
     // 데이터베이스 연결 실패 등 인프라 오류

--- a/src/main/kotlin/org/example/beyondubackend/common/filter/TraceIdFilter.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/filter/TraceIdFilter.kt
@@ -10,13 +10,17 @@ import java.util.*
 
 @Component
 class TraceIdFilter : OncePerRequestFilter() {
-
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
-        filterChain: FilterChain
+        filterChain: FilterChain,
     ) {
-        val traceId = UUID.randomUUID().toString().replace("-", "").take(16)
+        val traceId =
+            UUID
+                .randomUUID()
+                .toString()
+                .replace("-", "")
+                .take(16)
         try {
             MDC.put("traceId", traceId)
             filterChain.doFilter(request, response)

--- a/src/main/kotlin/org/example/beyondubackend/common/resolver/ExamScoreArgumentResolver.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/resolver/ExamScoreArgumentResolver.kt
@@ -15,28 +15,27 @@ import org.springframework.web.method.support.ModelAndViewContainer
  * QueryString에서 어학 시험 점수를 추출하여 Map으로 변환하는 ArgumentResolver
  */
 class ExamScoreArgumentResolver : HandlerMethodArgumentResolver {
-
-    override fun supportsParameter(parameter: MethodParameter): Boolean {
-        return parameter.hasParameterAnnotation(ExamScoreParams::class.java)
-    }
+    override fun supportsParameter(parameter: MethodParameter): Boolean = parameter.hasParameterAnnotation(ExamScoreParams::class.java)
 
     override fun resolveArgument(
         parameter: MethodParameter,
         mavContainer: ModelAndViewContainer?,
         webRequest: NativeWebRequest,
-        binderFactory: WebDataBinderFactory?
-    ): Map<String, Double> {
-        return ExamType.entries.mapNotNull { examType ->
-            val value = webRequest.getParameter(examType.paramName)?.toDoubleOrNull()
-            if (value != null) {
-                if (value < examType.minScore || value > examType.maxScore) {
-                    throw BusinessException(
-                        ErrorCode.INVALID_EXAM_SCORE,
-                        "${examType.displayName} 점수는 ${examType.minScore} ~ ${examType.maxScore} 범위여야 합니다."
-                    )
+        binderFactory: WebDataBinderFactory?,
+    ): Map<String, Double> =
+        ExamType.entries
+            .mapNotNull { examType ->
+                val value = webRequest.getParameter(examType.paramName)?.toDoubleOrNull()
+                if (value != null) {
+                    if (value < examType.minScore || value > examType.maxScore) {
+                        throw BusinessException(
+                            ErrorCode.INVALID_EXAM_SCORE,
+                            "${examType.displayName} 점수는 ${examType.minScore} ~ ${examType.maxScore} 범위여야 합니다.",
+                        )
+                    }
+                    examType.displayName to value
+                } else {
+                    null
                 }
-                examType.displayName to value
-            } else null
-        }.toMap()
-    }
+            }.toMap()
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/implement/LanguageRequirement.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/implement/LanguageRequirement.kt
@@ -6,5 +6,5 @@ class LanguageRequirement(
     var languageGroup: String,
     var examType: String,
     var minScore: Double,
-    var levelCode: String? = null
+    var levelCode: String? = null,
 )

--- a/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/implement/LanguageRequirementReader.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/implement/LanguageRequirementReader.kt
@@ -5,36 +5,32 @@ import org.springframework.stereotype.Component
 
 @Component
 class LanguageRequirementReader(
-    private val languageRequirementRepository: LanguageRequirementRepository
+    private val languageRequirementRepository: LanguageRequirementRepository,
 ) {
+    fun findByUniversityId(universityId: Long): List<LanguageRequirement> = languageRequirementRepository.findByUniversityId(universityId)
 
-    fun findByUniversityId(universityId: Long): List<LanguageRequirement> {
-        return languageRequirementRepository.findByUniversityId(universityId)
-    }
-
-    fun findByUniversityIds(universityIds: List<Long>): Map<Long, List<LanguageRequirement>> {
-        return languageRequirementRepository.findByUniversityIds(universityIds)
-    }
+    fun findByUniversityIds(universityIds: List<Long>): Map<Long, List<LanguageRequirement>> =
+        languageRequirementRepository.findByUniversityIds(universityIds)
 
     fun generateSummary(requirements: List<LanguageRequirement>): String? {
         if (requirements.isEmpty()) return null
 
         return requirements.joinToString(" / ") { requirement ->
             val examType = ExamType.fromDisplayName(requirement.examType)
-            val scoreText = if (examType != null) {
-                "${examType.prefix}${formatScore(requirement.minScore)}${examType.suffix}"
-            } else {
-                formatScore(requirement.minScore)
-            }
+            val scoreText =
+                if (examType != null) {
+                    "${examType.prefix}${formatScore(requirement.minScore)}${examType.suffix}"
+                } else {
+                    formatScore(requirement.minScore)
+                }
             "${requirement.examType} $scoreText"
         }
     }
 
-    private fun formatScore(score: Double): String {
-        return if (score % 1.0 == 0.0) {
+    private fun formatScore(score: Double): String =
+        if (score % 1.0 == 0.0) {
             score.toInt().toString()
         } else {
             score.toString()
         }
-    }
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/implement/LanguageRequirementRepository.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/implement/LanguageRequirementRepository.kt
@@ -2,5 +2,6 @@ package org.example.beyondubackend.domain.languagerequirement.implement
 
 interface LanguageRequirementRepository {
     fun findByUniversityId(universityId: Long): List<LanguageRequirement>
+
     fun findByUniversityIds(universityIds: List<Long>): Map<Long, List<LanguageRequirement>>
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/storage/LanguageRequirementEntity.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/storage/LanguageRequirementEntity.kt
@@ -9,21 +9,16 @@ class LanguageRequirementEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null,
-
     @Column(name = "university_id", nullable = false)
     var universityId: Long,
-
     @Column(name = "language_group", nullable = false)
     var languageGroup: String,
-
     @Column(name = "exam_type", nullable = false)
     var examType: String,
-
     @Column(name = "min_score", nullable = false)
     var minScore: Double,
-
     @Column(name = "level_code")
-    var levelCode: String? = null
+    var levelCode: String? = null,
 ) {
     companion object {
         fun from(languageRequirement: LanguageRequirement) =
@@ -33,18 +28,17 @@ class LanguageRequirementEntity(
                 languageGroup = languageRequirement.languageGroup,
                 examType = languageRequirement.examType,
                 minScore = languageRequirement.minScore,
-                levelCode = languageRequirement.levelCode
+                levelCode = languageRequirement.levelCode,
             )
     }
 
-    fun toDomain(): LanguageRequirement {
-        return LanguageRequirement(
+    fun toDomain(): LanguageRequirement =
+        LanguageRequirement(
             id = id,
             universityId = universityId,
             languageGroup = languageGroup,
             examType = examType,
             minScore = minScore,
-            levelCode = levelCode
+            levelCode = levelCode,
         )
-    }
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/storage/LanguageRequirementJpaRepository.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/storage/LanguageRequirementJpaRepository.kt
@@ -4,5 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface LanguageRequirementJpaRepository : JpaRepository<LanguageRequirementEntity, Long> {
     fun findByUniversityId(universityId: Long): List<LanguageRequirementEntity>
+
     fun findByUniversityIdIn(universityIds: List<Long>): List<LanguageRequirementEntity>
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/storage/LanguageRequirementRepositoryImpl.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/languagerequirement/storage/LanguageRequirementRepositoryImpl.kt
@@ -6,18 +6,18 @@ import org.springframework.stereotype.Repository
 
 @Repository
 class LanguageRequirementRepositoryImpl(
-    private val languageRequirementJpaRepository: LanguageRequirementJpaRepository
+    private val languageRequirementJpaRepository: LanguageRequirementJpaRepository,
 ) : LanguageRequirementRepository {
-
-    override fun findByUniversityId(universityId: Long): List<LanguageRequirement> {
-        return languageRequirementJpaRepository.findByUniversityId(universityId)
+    override fun findByUniversityId(universityId: Long): List<LanguageRequirement> =
+        languageRequirementJpaRepository
+            .findByUniversityId(universityId)
             .map { it.toDomain() }
-    }
 
     override fun findByUniversityIds(universityIds: List<Long>): Map<Long, List<LanguageRequirement>> {
         if (universityIds.isEmpty()) return emptyMap()
 
-        return languageRequirementJpaRepository.findByUniversityIdIn(universityIds)
+        return languageRequirementJpaRepository
+            .findByUniversityIdIn(universityIds)
             .groupBy { it.universityId }
             .mapValues { entry -> entry.value.map { it.toDomain() } }
     }

--- a/src/main/kotlin/org/example/beyondubackend/domain/meta/application/MetaController.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/meta/application/MetaController.kt
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/meta")
 class MetaController {
-
     @Operation(summary = "국가 목록 조회", description = "university 필터링에 사용 가능한 국가 목록을 반환합니다.")
     @GetMapping("/nations")
     fun getNations(): ResponseEntity<ApiResponse<List<String>>> {

--- a/src/main/kotlin/org/example/beyondubackend/domain/meta/application/MetaController.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/meta/application/MetaController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.example.beyondubackend.common.dto.ApiResponse
 import org.example.beyondubackend.common.enums.ExamType
 import org.example.beyondubackend.common.enums.Nation
+import org.example.beyondubackend.common.enums.Region
 import org.example.beyondubackend.domain.meta.application.dto.ExamTypeResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,6 +22,13 @@ class MetaController {
     fun getNations(): ResponseEntity<ApiResponse<List<String>>> {
         val nations = Nation.entries.map { it.displayName }
         return ApiResponse.success(nations)
+    }
+
+    @Operation(summary = "대륙 목록 조회", description = "university 필터링에 사용 가능한 대륙 목록을 반환합니다.")
+    @GetMapping("/regions")
+    fun getRegions(): ResponseEntity<ApiResponse<List<String>>> {
+        val regions = Region.entries.map { it.displayName }
+        return ApiResponse.success(regions)
     }
 
     @Operation(summary = "어학 시험 목록 조회", description = "지원하는 어학 시험 종류와 점수 범위를 반환합니다.")

--- a/src/main/kotlin/org/example/beyondubackend/domain/meta/application/dto/ExamTypeResponse.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/meta/application/dto/ExamTypeResponse.kt
@@ -6,14 +6,15 @@ data class ExamTypeResponse(
     val paramName: String,
     val displayName: String,
     val minScore: Double,
-    val maxScore: Double
+    val maxScore: Double,
 ) {
     companion object {
-        fun from(examType: ExamType) = ExamTypeResponse(
-            paramName = examType.paramName,
-            displayName = examType.displayName,
-            minScore = examType.minScore,
-            maxScore = examType.maxScore
-        )
+        fun from(examType: ExamType) =
+            ExamTypeResponse(
+                paramName = examType.paramName,
+                displayName = examType.displayName,
+                minScore = examType.minScore,
+                maxScore = examType.maxScore,
+            )
     }
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/application/UniversityController.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/application/UniversityController.kt
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.RequestParam
 
 @Tag(name = "University", description = "대학교 조회 API")
 interface UniversityController {
-
     @Operation(
         summary = "대학교 목록 조회",
         description = """
@@ -28,65 +27,97 @@ interface UniversityController {
             - 어학 점수 필터: TOEFL_IBT, TOEFL_ITP, IELTS, TOEIC, TOEIC_Speaking, HSK, JLPT, JPT, DELF, ZD
             - 페이지네이션: page (기본값 0), size (기본값 12)
             - 모든 파라미터는 optional이며, null이면 전체 조회
-        """
+        """,
     )
-    @Parameters(value = [
-        Parameter(
-            name = "TOEFL_IBT", description = "TOEFL iBT 점수",
-            required = false, `in` = ParameterIn.QUERY, schema = Schema(type = "number", example = "80")
-        ),
-        Parameter(
-            name = "TOEFL_ITP", description = "TOEFL ITP 점수",
-            required = false, `in` = ParameterIn.QUERY, schema = Schema(type = "number", example = "550")
-        ),
-        Parameter(
-            name = "IELTS", description = "IELTS 점수",
-            required = false, `in` = ParameterIn.QUERY, schema = Schema(type = "number", example = "6.5")
-        ),
-        Parameter(
-            name = "TOEIC", description = "TOEIC 점수",
-            required = false, `in` = ParameterIn.QUERY, schema = Schema(type = "number", example = "800")
-        ),
-        Parameter(
-            name = "TOEIC_Speaking", description = "TOEIC Speaking 점수",
-            required = false, `in` = ParameterIn.QUERY, schema = Schema(type = "number", example = "160")
-        ),
-        Parameter(
-            name = "HSK", description = "HSK 급수",
-            required = false, `in` = ParameterIn.QUERY, schema = Schema(type = "number", example = "4")
-        ),
-        Parameter(
-            name = "JLPT", description = "JLPT 레벨 (1=N1 ~ 5=N5, 숫자가 낮을수록 높은 레벨)",
-            required = false, `in` = ParameterIn.QUERY, schema = Schema(type = "number", example = "2")
-        ),
-        Parameter(
-            name = "JPT", description = "JPT 점수",
-            required = false, `in` = ParameterIn.QUERY, schema = Schema(type = "number", example = "700")
-        ),
-        Parameter(
-            name = "DELF", description = "DELF 급수",
-            required = false, `in` = ParameterIn.QUERY, schema = Schema(type = "number", example = "4")
-        ),
-        Parameter(
-            name = "ZD", description = "ZD 급수 (독어 자격증)",
-            required = false, `in` = ParameterIn.QUERY, schema = Schema(type = "number", example = "4")
-        )
-    ])
+    @Parameters(
+        value = [
+            Parameter(
+                name = "TOEFL_IBT",
+                description = "TOEFL iBT 점수",
+                required = false,
+                `in` = ParameterIn.QUERY,
+                schema = Schema(type = "number", example = "80"),
+            ),
+            Parameter(
+                name = "TOEFL_ITP",
+                description = "TOEFL ITP 점수",
+                required = false,
+                `in` = ParameterIn.QUERY,
+                schema = Schema(type = "number", example = "550"),
+            ),
+            Parameter(
+                name = "IELTS",
+                description = "IELTS 점수",
+                required = false,
+                `in` = ParameterIn.QUERY,
+                schema = Schema(type = "number", example = "6.5"),
+            ),
+            Parameter(
+                name = "TOEIC",
+                description = "TOEIC 점수",
+                required = false,
+                `in` = ParameterIn.QUERY,
+                schema = Schema(type = "number", example = "800"),
+            ),
+            Parameter(
+                name = "TOEIC_Speaking",
+                description = "TOEIC Speaking 점수",
+                required = false,
+                `in` = ParameterIn.QUERY,
+                schema = Schema(type = "number", example = "160"),
+            ),
+            Parameter(
+                name = "HSK",
+                description = "HSK 급수",
+                required = false,
+                `in` = ParameterIn.QUERY,
+                schema = Schema(type = "number", example = "4"),
+            ),
+            Parameter(
+                name = "JLPT",
+                description = "JLPT 레벨 (1=N1 ~ 5=N5, 숫자가 낮을수록 높은 레벨)",
+                required = false,
+                `in` = ParameterIn.QUERY,
+                schema = Schema(type = "number", example = "2"),
+            ),
+            Parameter(
+                name = "JPT",
+                description = "JPT 점수",
+                required = false,
+                `in` = ParameterIn.QUERY,
+                schema = Schema(type = "number", example = "700"),
+            ),
+            Parameter(
+                name = "DELF",
+                description = "DELF 급수",
+                required = false,
+                `in` = ParameterIn.QUERY,
+                schema = Schema(type = "number", example = "4"),
+            ),
+            Parameter(
+                name = "ZD",
+                description = "ZD 급수 (독어 자격증)",
+                required = false,
+                `in` = ParameterIn.QUERY,
+                schema = Schema(type = "number", example = "4"),
+            ),
+        ],
+    )
     fun getUniversities(
         @ParameterObject @ModelAttribute request: UniversitySearchRequest,
         @Parameter(hidden = true) @ExamScoreParams examScores: Map<String, Double>,
         @Parameter(description = "페이지 번호", example = "0")
         @RequestParam(defaultValue = "0") page: Int,
         @Parameter(description = "페이지 크기", example = "12")
-        @RequestParam(defaultValue = "12") size: Int
+        @RequestParam(defaultValue = "12") size: Int,
     ): ResponseEntity<ApiResponse<UniversityListResponse>>
 
     @Operation(
         summary = "대학교 상세 조회",
-        description = "대학교 ID로 상세 정보를 조회합니다. 언어 요구사항 정보도 함께 반환됩니다."
+        description = "대학교 ID로 상세 정보를 조회합니다. 언어 요구사항 정보도 함께 반환됩니다.",
     )
     fun getUniversityDetail(
         @Parameter(description = "대학교 ID", example = "1", required = true)
-        @PathVariable id: Long
+        @PathVariable id: Long,
     ): ResponseEntity<ApiResponse<UniversityDetailResponse>>
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/application/UniversityControllerImpl.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/application/UniversityControllerImpl.kt
@@ -15,15 +15,14 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/api/v1/universities")
 class UniversityControllerImpl(
-    private val universityService: UniversityService
+    private val universityService: UniversityService,
 ) : UniversityController {
-
     @GetMapping
     override fun getUniversities(
         @ParameterObject @ModelAttribute request: UniversitySearchRequest,
         @ExamScoreParams examScores: Map<String, Double>,
         @RequestParam(defaultValue = "0") page: Int,
-        @RequestParam(defaultValue = "12") size: Int
+        @RequestParam(defaultValue = "12") size: Int,
     ): ResponseEntity<ApiResponse<UniversityListResponse>> {
         val pageable = PageRequest.of(page, size, Sort.by(Sort.Order.asc("nameEng"), Sort.Order.asc("nameKor")))
         val query = request.toQuery(examScores)
@@ -33,7 +32,7 @@ class UniversityControllerImpl(
 
     @GetMapping("/{id}")
     override fun getUniversityDetail(
-        @PathVariable id: Long
+        @PathVariable id: Long,
     ): ResponseEntity<ApiResponse<UniversityDetailResponse>> {
         val result = universityService.getUniversityDetail(id)
         return ApiResponse.success(result)

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/application/dto/UniversitySearchRequest.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/application/dto/UniversitySearchRequest.kt
@@ -1,11 +1,19 @@
 package org.example.beyondubackend.domain.university.application.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.example.beyondubackend.common.code.ErrorCode
+import org.example.beyondubackend.common.enums.Nation
+import org.example.beyondubackend.common.enums.Region
+import org.example.beyondubackend.common.exception.BusinessException
 import org.example.beyondubackend.domain.university.business.query.UniversityQuery
 
 data class UniversitySearchRequest(
-    @Schema(description = "국가 필터 (예: 미국, 일본)")
+    @Schema(description = "국가 필터 단일값 (하위 호환, 예: ?nation=USA)")
     val nation: String? = null,
+    @Schema(description = "국가 필터 복수값 (예: ?nations=USA&nations=JPN)", example = "USA")
+    val nations: List<String>? = null,
+    @Schema(description = "대륙 필터 (예: 유럽, 아시아, 북미, 남미, 오세아니아, 아프리카)")
+    val region: String? = null,
     @Schema(description = "교환학생 가능 여부")
     val isExchange: Boolean? = null,
     @Schema(description = "방문학생 가능 여부")
@@ -21,8 +29,18 @@ data class UniversitySearchRequest(
     val hasReview: Boolean? = null
 ) {
     fun toQuery(examScores: Map<String, Double>): UniversityQuery {
+        val mergedNations = (nations.orEmpty() + listOfNotNull(nation))
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .takeIf { it.isNotEmpty() }
+
+        validateNations(mergedNations)
+        validateRegion(region)
+
         return UniversityQuery(
-            nation = nation,
+            nations = mergedNations,
+            region = region,
             isExchange = isExchange,
             isVisit = isVisit,
             search = search,
@@ -31,5 +49,22 @@ data class UniversitySearchRequest(
             hasReview = hasReview,
             examScores = examScores
         )
+    }
+
+    private fun validateNations(nations: List<String>?) {
+        if (nations.isNullOrEmpty()) return
+        val validNames = Nation.entries.map { it.name }.toSet()
+        val invalid = nations.filter { it !in validNames }
+        if (invalid.isNotEmpty()) {
+            throw BusinessException(ErrorCode.INVALID_INPUT, "유효하지 않은 국가 코드: ${invalid.joinToString()}")
+        }
+    }
+
+    private fun validateRegion(region: String?) {
+        if (region == null) return
+        val validNames = Region.entries.map { it.displayName }.toSet()
+        if (region !in validNames) {
+            throw BusinessException(ErrorCode.INVALID_INPUT, "유효하지 않은 대륙: $region")
+        }
     }
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/application/dto/UniversitySearchRequest.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/application/dto/UniversitySearchRequest.kt
@@ -18,7 +18,7 @@ data class UniversitySearchRequest(
     val isExchange: Boolean? = null,
     @Schema(description = "방문학생 가능 여부")
     val isVisit: Boolean? = null,
-    //TO DO: 대학 이름 검색 사용시 추가
+    // TO DO: 대학 이름 검색 사용시 추가
     @Schema(hidden = true)
     val search: String? = null,
     @Schema(description = "최소 GPA (입력한 GPA 이상 지원 가능한 학교 조회)", example = "3.5")
@@ -26,14 +26,15 @@ data class UniversitySearchRequest(
     @Schema(description = "전공 필터")
     val major: String? = null,
     @Schema(description = "후기 보유 여부")
-    val hasReview: Boolean? = null
+    val hasReview: Boolean? = null,
 ) {
     fun toQuery(examScores: Map<String, Double>): UniversityQuery {
-        val mergedNations = (nations.orEmpty() + listOfNotNull(nation))
-            .map { it.trim() }
-            .filter { it.isNotBlank() }
-            .distinct()
-            .takeIf { it.isNotEmpty() }
+        val mergedNations =
+            (nations.orEmpty() + listOfNotNull(nation))
+                .map { it.trim() }
+                .filter { it.isNotBlank() }
+                .distinct()
+                .takeIf { it.isNotEmpty() }
 
         validateNations(mergedNations)
         validateRegion(region)
@@ -47,7 +48,7 @@ data class UniversitySearchRequest(
             gpa = gpa,
             major = major,
             hasReview = hasReview,
-            examScores = examScores
+            examScores = examScores,
         )
     }
 

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/business/UniversityService.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/business/UniversityService.kt
@@ -6,8 +6,10 @@ import org.example.beyondubackend.domain.university.business.query.UniversityQue
 import org.springframework.data.domain.Pageable
 
 interface UniversityService {
-
-    fun getUniversities(query: UniversityQuery, pageable: Pageable): UniversityListResponse
+    fun getUniversities(
+        query: UniversityQuery,
+        pageable: Pageable,
+    ): UniversityListResponse
 
     fun getUniversityDetail(id: Long): UniversityDetailResponse
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/business/UniversityServiceImpl.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/business/UniversityServiceImpl.kt
@@ -20,7 +20,8 @@ class UniversityServiceImpl(
 
     override fun getUniversities(query: UniversityQuery, pageable: Pageable): UniversityListResponse {
         val universityPage = universityReader.getUniversitiesWithFilters(
-            nation = query.nation,
+            nations = query.nations,
+            region = query.region,
             isExchange = query.isExchange,
             isVisit = query.isVisit,
             search = query.search,

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/business/UniversityServiceImpl.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/business/UniversityServiceImpl.kt
@@ -15,54 +15,62 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class UniversityServiceImpl(
     private val universityReader: UniversityReader,
-    private val languageRequirementReader: LanguageRequirementReader
+    private val languageRequirementReader: LanguageRequirementReader,
 ) : UniversityService {
-
-    override fun getUniversities(query: UniversityQuery, pageable: Pageable): UniversityListResponse {
-        val universityPage = universityReader.getUniversitiesWithFilters(
-            nations = query.nations,
-            region = query.region,
-            isExchange = query.isExchange,
-            isVisit = query.isVisit,
-            search = query.search,
-            gpa = query.gpa,
-            major = query.major,
-            hasReview = query.hasReview,
-            examScores = query.examScores,
-            pageable = pageable
-        )
+    override fun getUniversities(
+        query: UniversityQuery,
+        pageable: Pageable,
+    ): UniversityListResponse {
+        val universityPage =
+            universityReader.getUniversitiesWithFilters(
+                nations = query.nations,
+                region = query.region,
+                isExchange = query.isExchange,
+                isVisit = query.isVisit,
+                search = query.search,
+                gpa = query.gpa,
+                major = query.major,
+                hasReview = query.hasReview,
+                examScores = query.examScores,
+                pageable = pageable,
+            )
 
         // 대학 ID 목록 추출
         val universityIds = universityPage.content.map { it.id!! }
 
         // 언어 요구사항 일괄 조회
-        val languageRequirementsMap = if (universityIds.isNotEmpty()) {
-            languageRequirementReader.findByUniversityIds(universityIds)
-        } else {
-            emptyMap()
-        }
+        val languageRequirementsMap =
+            if (universityIds.isNotEmpty()) {
+                languageRequirementReader.findByUniversityIds(universityIds)
+            } else {
+                emptyMap()
+            }
 
         // DTO 변환 (languageRequirementSummary 포함)
-        val universities = universityPage.content.map { university ->
-            val requirements = languageRequirementsMap[university.id] ?: emptyList()
-            val summary = languageRequirementReader.generateSummary(requirements)
-            UniversityListResponse.UniversitySummaryDto.from(university, summary)
-        }
+        val universities =
+            universityPage.content.map { university ->
+                val requirements = languageRequirementsMap[university.id] ?: emptyList()
+                val summary = languageRequirementReader.generateSummary(requirements)
+                UniversityListResponse.UniversitySummaryDto.from(university, summary)
+            }
 
-        val pageInfo = PageInfo(
-            currentPage = universityPage.number,
-            totalElements = universityPage.totalElements,
-            totalPages = universityPage.totalPages,
-            isLast = universityPage.isLast
-        )
+        val pageInfo =
+            PageInfo(
+                currentPage = universityPage.number,
+                totalElements = universityPage.totalElements,
+                totalPages = universityPage.totalPages,
+                isLast = universityPage.isLast,
+            )
 
         return UniversityListResponse(universities, pageInfo)
     }
 
     override fun getUniversityDetail(id: Long): UniversityDetailResponse {
         val university = universityReader.getUniversityById(id)
-        val languageRequirements = languageRequirementReader.findByUniversityId(id)
-            .map { LanguageRequirementResponse.from(it) }
+        val languageRequirements =
+            languageRequirementReader
+                .findByUniversityId(id)
+                .map { LanguageRequirementResponse.from(it) }
 
         return UniversityDetailResponse.from(university, languageRequirements)
     }

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/business/dto/LanguageRequirementResponse.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/business/dto/LanguageRequirementResponse.kt
@@ -5,15 +5,14 @@ import org.example.beyondubackend.domain.languagerequirement.implement.LanguageR
 data class LanguageRequirementResponse(
     val languageGroup: String,
     val examType: String,
-    val minScore: Double
+    val minScore: Double,
 ) {
     companion object {
-        fun from(languageRequirement: LanguageRequirement): LanguageRequirementResponse {
-            return LanguageRequirementResponse(
+        fun from(languageRequirement: LanguageRequirement): LanguageRequirementResponse =
+            LanguageRequirementResponse(
                 languageGroup = languageRequirement.languageGroup,
                 examType = languageRequirement.examType,
-                minScore = languageRequirement.minScore
+                minScore = languageRequirement.minScore,
             )
-        }
     }
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/business/dto/UniversityDetailResponse.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/business/dto/UniversityDetailResponse.kt
@@ -1,6 +1,7 @@
 package org.example.beyondubackend.domain.university.business.dto
 
 import org.example.beyondubackend.domain.university.implement.University
+import java.util.Base64
 
 data class UniversityDetailResponse(
     val id: Long,
@@ -46,7 +47,10 @@ data class UniversityDetailResponse(
                 programType = programType,
                 badge = university.badge,
                 hasReview = university.hasReview,
-                reviewReportUrl = null, // TODO #38: hasReview=true일 때 Base64(nameEng) URL 생성
+                reviewReportUrl = if (university.hasReview) {
+                    val encoded = Base64.getEncoder().encodeToString(university.nameEng.toByteArray(Charsets.UTF_8))
+                    "https://study.ssu.ac.kr/community/exp_list.do?searchVal=$encoded&siteCd=01&boardCd=07"
+                } else null,
                 minGpa = university.minGpa,
                 websiteUrl = university.websiteUrl,
                 significantNote = university.significantNote,

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/business/dto/UniversityDetailResponse.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/business/dto/UniversityDetailResponse.kt
@@ -1,7 +1,7 @@
 package org.example.beyondubackend.domain.university.business.dto
 
 import org.example.beyondubackend.domain.university.implement.University
-import java.util.Base64
+import java.util.*
 
 data class UniversityDetailResponse(
     val id: Long,
@@ -28,13 +28,14 @@ data class UniversityDetailResponse(
     companion object {
         fun from(
             university: University,
-            languageRequirements: List<LanguageRequirementResponse>
+            languageRequirements: List<LanguageRequirementResponse>,
         ): UniversityDetailResponse {
-            val programType = when {
-                university.isExchange -> "일반교환"
-                university.isVisit -> "방문교환"
-                else -> ""
-            }
+            val programType =
+                when {
+                    university.isExchange -> "일반교환"
+                    university.isVisit -> "방문교환"
+                    else -> ""
+                }
 
             return UniversityDetailResponse(
                 id = university.id!!,
@@ -47,20 +48,24 @@ data class UniversityDetailResponse(
                 programType = programType,
                 badge = university.badge,
                 hasReview = university.hasReview,
-                reviewReportUrl = if (university.hasReview) {
-                    val encoded = Base64.getEncoder().encodeToString(university.nameEng.toByteArray(Charsets.UTF_8))
-                    "https://study.ssu.ac.kr/community/exp_list.do?searchVal=$encoded&siteCd=01&boardCd=07"
-                } else null,
+                reviewReportUrl =
+                    if (university.hasReview) {
+                        val encoded = Base64.getEncoder().encodeToString(university.nameEng.toByteArray(Charsets.UTF_8))
+                        "https://study.ssu.ac.kr/community/exp_list.do?searchVal=$encoded&siteCd=01&boardCd=07"
+                    } else {
+                        null
+                    },
                 minGpa = university.minGpa,
                 websiteUrl = university.websiteUrl,
                 significantNote = university.significantNote,
                 remark = university.remark,
                 languageRequirements = languageRequirements,
-                availableMajors = university.availableMajor
-                    ?.split(",")
-                    ?.map { it.trim() }
-                    ?.filter { it.isNotBlank() }
-                    ?.takeIf { it.isNotEmpty() },
+                availableMajors =
+                    university.availableMajor
+                        ?.split(",")
+                        ?.map { it.trim() }
+                        ?.filter { it.isNotBlank() }
+                        ?.takeIf { it.isNotEmpty() },
                 courseListUrl = university.availableSubject,
                 studentCount = university.studentCount,
                 location = university.location,

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/business/dto/UniversityDetailResponse.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/business/dto/UniversityDetailResponse.kt
@@ -13,6 +13,7 @@ data class UniversityDetailResponse(
     val programType: String,
     val badge: String,
     val hasReview: Boolean,
+    val reviewReportUrl: String?,
     val minGpa: Double,
     val websiteUrl: String?,
     val significantNote: String?,
@@ -45,6 +46,7 @@ data class UniversityDetailResponse(
                 programType = programType,
                 badge = university.badge,
                 hasReview = university.hasReview,
+                reviewReportUrl = null, // TODO #38: hasReview=true일 때 Base64(nameEng) URL 생성
                 minGpa = university.minGpa,
                 websiteUrl = university.websiteUrl,
                 significantNote = university.significantNote,

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/business/dto/UniversityListResponse.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/business/dto/UniversityListResponse.kt
@@ -5,7 +5,7 @@ import org.example.beyondubackend.domain.university.implement.University
 
 data class UniversityListResponse(
     val universities: List<UniversitySummaryDto>,
-    val pageInfo: PageInfo
+    val pageInfo: PageInfo,
 ) {
     data class UniversitySummaryDto(
         val id: Long,
@@ -17,24 +17,29 @@ data class UniversityListResponse(
         val isVisit: Boolean,
         val programType: String,
         val languageRequirementSummary: String?,
-        val reviewStatus: String
+        val reviewStatus: String,
     ) {
         companion object {
-            fun from(university: University, languageRequirementSummary: String?): UniversitySummaryDto {
-                val reviewStatus = when {
-                    university.hasReview && university.reviewYear != null ->
-                        "후기 있음 (${university.reviewYear})"
-                    university.hasReview ->
-                        "후기 있음"
-                    else ->
-                        "후기 없음"
-                }
+            fun from(
+                university: University,
+                languageRequirementSummary: String?,
+            ): UniversitySummaryDto {
+                val reviewStatus =
+                    when {
+                        university.hasReview && university.reviewYear != null ->
+                            "후기 있음 (${university.reviewYear})"
+                        university.hasReview ->
+                            "후기 있음"
+                        else ->
+                            "후기 없음"
+                    }
 
-                val programType = when {
-                    university.isExchange -> "일반교환"
-                    university.isVisit -> "방문교환"
-                    else -> ""
-                }
+                val programType =
+                    when {
+                        university.isExchange -> "일반교환"
+                        university.isVisit -> "방문교환"
+                        else -> ""
+                    }
 
                 return UniversitySummaryDto(
                     id = university.id!!,
@@ -46,7 +51,7 @@ data class UniversityListResponse(
                     isVisit = university.isVisit,
                     programType = programType,
                     languageRequirementSummary = languageRequirementSummary,
-                    reviewStatus = reviewStatus
+                    reviewStatus = reviewStatus,
                 )
             }
         }

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/business/query/UniversityQuery.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/business/query/UniversityQuery.kt
@@ -1,7 +1,8 @@
 package org.example.beyondubackend.domain.university.business.query
 
 data class UniversityQuery(
-    val nation: String? = null,
+    val nations: List<String>? = null,
+    val region: String? = null,
     val isExchange: Boolean? = null,
     val isVisit: Boolean? = null,
     val search: String? = null,

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/business/query/UniversityQuery.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/business/query/UniversityQuery.kt
@@ -9,5 +9,5 @@ data class UniversityQuery(
     val gpa: Double? = null,
     val major: String? = null,
     val hasReview: Boolean? = null,
-    val examScores: Map<String, Double> = emptyMap()
+    val examScores: Map<String, Double> = emptyMap(),
 )

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/implement/University.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/implement/University.kt
@@ -19,5 +19,5 @@ class University(
     var isVisit: Boolean,
     var badge: String = "",
     var hasReview: Boolean = false,
-    var reviewYear: String? = null
+    var reviewYear: String? = null,
 )

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/implement/UniversityReader.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/implement/UniversityReader.kt
@@ -8,9 +8,8 @@ import org.springframework.stereotype.Component
 
 @Component
 class UniversityReader(
-    private val universityRepository: UniversityRepository
+    private val universityRepository: UniversityRepository,
 ) {
-
     fun getUniversitiesWithFilters(
         nations: List<String>?,
         region: String?,
@@ -21,15 +20,22 @@ class UniversityReader(
         major: String?,
         hasReview: Boolean?,
         examScores: Map<String, Double>,
-        pageable: Pageable
-    ): Page<University> {
-        return universityRepository.findAllWithFilters(
-            nations, region, isExchange, isVisit, search, gpa, major, hasReview, examScores, pageable
+        pageable: Pageable,
+    ): Page<University> =
+        universityRepository.findAllWithFilters(
+            nations,
+            region,
+            isExchange,
+            isVisit,
+            search,
+            gpa,
+            major,
+            hasReview,
+            examScores,
+            pageable,
         )
-    }
 
-    fun getUniversityById(id: Long): University {
-        return universityRepository.findById(id)
+    fun getUniversityById(id: Long): University =
+        universityRepository.findById(id)
             ?: throw BusinessException(ErrorCode.UNIVERSITY_NOT_FOUND)
-    }
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/implement/UniversityReader.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/implement/UniversityReader.kt
@@ -12,7 +12,8 @@ class UniversityReader(
 ) {
 
     fun getUniversitiesWithFilters(
-        nation: String?,
+        nations: List<String>?,
+        region: String?,
         isExchange: Boolean?,
         isVisit: Boolean?,
         search: String?,
@@ -23,7 +24,7 @@ class UniversityReader(
         pageable: Pageable
     ): Page<University> {
         return universityRepository.findAllWithFilters(
-            nation, isExchange, isVisit, search, gpa, major, hasReview, examScores, pageable
+            nations, region, isExchange, isVisit, search, gpa, major, hasReview, examScores, pageable
         )
     }
 

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/implement/UniversityRepository.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/implement/UniversityRepository.kt
@@ -5,7 +5,8 @@ import org.springframework.data.domain.Pageable
 
 interface UniversityRepository {
     fun findAllWithFilters(
-        nation: String?,
+        nations: List<String>?,
+        region: String?,
         isExchange: Boolean?,
         isVisit: Boolean?,
         search: String?,

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/implement/UniversityRepository.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/implement/UniversityRepository.kt
@@ -14,7 +14,7 @@ interface UniversityRepository {
         major: String?,
         hasReview: Boolean?,
         examScores: Map<String, Double>,
-        pageable: Pageable
+        pageable: Pageable,
     ): Page<University>
 
     fun findById(id: Long): University?

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/storage/UniversityEntity.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/storage/UniversityEntity.kt
@@ -10,88 +10,70 @@ class UniversityEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
-
     @Column(nullable = false)
     var semester: String,
-
     @Column(nullable = false)
     var region: String,
-
     @Column(nullable = false)
     var nation: String,
-
     @Column(name = "name_kor", nullable = false)
     var nameKor: String,
-
     @Column(name = "name_eng", nullable = false)
     var nameEng: String,
-
     @Column(name = "min_gpa", nullable = false)
     var minGpa: Double,
-
     @Column(name = "significant_note", columnDefinition = "TEXT", nullable = true)
     var significantNote: String? = null,
-
     @Column(columnDefinition = "TEXT", nullable = false)
     var remark: String,
-
     @Column(name = "location", nullable = true)
     var location: String? = null,
-
     @Column(name = "student_count", nullable = true)
     var studentCount: String? = null,
-
     @Column(columnDefinition = "TEXT", name = "available_major", nullable = true)
     var availableMajor: String? = null,
-
     @Column(columnDefinition = "TEXT", name = "available_subject", nullable = true)
     var availableSubject: String? = null,
-
     @Column(name = "website_url", columnDefinition = "TEXT", nullable = true)
     var websiteUrl: String? = null,
-
     @Column(name = "is_exchange", nullable = false)
     var isExchange: Boolean,
-
     @Column(name = "is_visit", nullable = false)
     var isVisit: Boolean,
-
     @Column(nullable = true)
     var badge: String? = null,
-
     @Column(name = "has_review", nullable = false)
     var hasReview: Boolean = false,
-
     @Column(name = "review_year", nullable = true)
-    var reviewYear: String? = null
-
+    var reviewYear: String? = null,
 ) : BaseEntity() {
     companion object {
-        fun from(university: University) = UniversityEntity(
-            id = university.id,
-            semester = university.semester,
-            region = university.region,
-            nation = university.nation,
-            nameKor = university.nameKor,
-            nameEng = university.nameEng,
-            minGpa = university.minGpa,
-            significantNote = university.significantNote,
-            remark = university.remark,
-            location = university.location,
-            studentCount = university.studentCount,
-            availableMajor = university.availableMajor,
-            availableSubject = university.availableSubject,
-            websiteUrl = university.websiteUrl,
-            isExchange = university.isExchange,
-            isVisit = university.isVisit,
-            badge = university.badge,
-            hasReview = university.hasReview,
-            reviewYear = university.reviewYear
-        )
+        fun from(university: University) =
+            UniversityEntity(
+                id = university.id,
+                semester = university.semester,
+                region = university.region,
+                nation = university.nation,
+                nameKor = university.nameKor,
+                nameEng = university.nameEng,
+                minGpa = university.minGpa,
+                significantNote = university.significantNote,
+                remark = university.remark,
+                location = university.location,
+                studentCount = university.studentCount,
+                availableMajor = university.availableMajor,
+                availableSubject = university.availableSubject,
+                websiteUrl = university.websiteUrl,
+                isExchange = university.isExchange,
+                isVisit = university.isVisit,
+                badge = university.badge,
+                hasReview = university.hasReview,
+                reviewYear = university.reviewYear,
+            )
     }
 
-    fun toDomain(): University {
-        return University(
+    fun toDomain(): University =
+        University(
             id = id,
             semester = semester,
             region = region,
@@ -110,7 +92,6 @@ class UniversityEntity(
             isVisit = isVisit,
             badge = badge ?: "",
             hasReview = hasReview,
-            reviewYear = reviewYear
+            reviewYear = reviewYear,
         )
-    }
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/storage/UniversityRepositoryImpl.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/storage/UniversityRepositoryImpl.kt
@@ -16,9 +16,8 @@ import org.springframework.stereotype.Repository
 @Repository
 class UniversityRepositoryImpl(
     private val universityJpaRepository: UniversityJpaRepository,
-    private val queryFactory: JPAQueryFactory
+    private val queryFactory: JPAQueryFactory,
 ) : UniversityRepository {
-
     override fun findAllWithFilters(
         nations: List<String>?,
         region: String?,
@@ -29,125 +28,123 @@ class UniversityRepositoryImpl(
         major: String?,
         hasReview: Boolean?,
         examScores: Map<String, Double>,
-        pageable: Pageable
+        pageable: Pageable,
     ): Page<University> {
-
-        val query = queryFactory
-            .selectFrom(universityEntity)
-            .where(
-                nationsIn(nations),
-                regionEq(region),
-                isExchangeEq(isExchange),
-                isVisitEq(isVisit),
-                searchKeyword(search),
-                gpaLoe(gpa),
-                majorContains(major),
-                hasReviewEq(hasReview),
-                examScoresMatch(examScores)
-            )
-            .offset(pageable.offset)
-            .limit(pageable.pageSize.toLong())
+        val query =
+            queryFactory
+                .selectFrom(universityEntity)
+                .where(
+                    nationsIn(nations),
+                    regionEq(region),
+                    isExchangeEq(isExchange),
+                    isVisitEq(isVisit),
+                    searchKeyword(search),
+                    gpaLoe(gpa),
+                    majorContains(major),
+                    hasReviewEq(hasReview),
+                    examScoresMatch(examScores),
+                ).offset(pageable.offset)
+                .limit(pageable.pageSize.toLong())
 
         pageable.sort.forEach { order ->
             when (order.property) {
-                "nameEng" -> if (order.isAscending) query.orderBy(universityEntity.nameEng.asc())
-                            else query.orderBy(universityEntity.nameEng.desc())
-                "nameKor" -> if (order.isAscending) query.orderBy(universityEntity.nameKor.asc())
-                            else query.orderBy(universityEntity.nameKor.desc())
+                "nameEng" ->
+                    if (order.isAscending) {
+                        query.orderBy(universityEntity.nameEng.asc())
+                    } else {
+                        query.orderBy(universityEntity.nameEng.desc())
+                    }
+                "nameKor" ->
+                    if (order.isAscending) {
+                        query.orderBy(universityEntity.nameKor.asc())
+                    } else {
+                        query.orderBy(universityEntity.nameKor.desc())
+                    }
             }
         }
 
         val content = query.fetch().map { it.toDomain() }
-        val total = queryFactory
-            .select(universityEntity.count())
-            .from(universityEntity)
-            .where(
-                nationsIn(nations),
-                regionEq(region),
-                isExchangeEq(isExchange),
-                isVisitEq(isVisit),
-                searchKeyword(search),
-                gpaLoe(gpa),
-                majorContains(major),
-                hasReviewEq(hasReview),
-                examScoresMatch(examScores)
-            )
-            .fetchOne() ?: 0L
+        val total =
+            queryFactory
+                .select(universityEntity.count())
+                .from(universityEntity)
+                .where(
+                    nationsIn(nations),
+                    regionEq(region),
+                    isExchangeEq(isExchange),
+                    isVisitEq(isVisit),
+                    searchKeyword(search),
+                    gpaLoe(gpa),
+                    majorContains(major),
+                    hasReviewEq(hasReview),
+                    examScoresMatch(examScores),
+                ).fetchOne() ?: 0L
 
         return PageImpl(content, pageable, total)
     }
 
-    override fun findById(id: Long): University? {
-        return universityJpaRepository.findById(id).orElse(null)?.toDomain()
-    }
+    override fun findById(id: Long): University? = universityJpaRepository.findById(id).orElse(null)?.toDomain()
 
-    private fun nationsIn(nations: List<String>?): BooleanExpression? {
-        return nations?.takeIf { it.isNotEmpty() }?.let { universityEntity.nation.`in`(it) }
-    }
+    private fun nationsIn(nations: List<String>?): BooleanExpression? =
+        nations
+            ?.takeIf {
+                it.isNotEmpty()
+            }?.let { universityEntity.nation.`in`(it) }
 
-    private fun regionEq(region: String?): BooleanExpression? {
-        return region?.let { universityEntity.region.eq(it) }
-    }
+    private fun regionEq(region: String?): BooleanExpression? = region?.let { universityEntity.region.eq(it) }
 
-    private fun isExchangeEq(isExchange: Boolean?): BooleanExpression? {
-        return isExchange?.let { universityEntity.isExchange.eq(it) }
-    }
+    private fun isExchangeEq(isExchange: Boolean?): BooleanExpression? = isExchange?.let { universityEntity.isExchange.eq(it) }
 
-    private fun isVisitEq(isVisit: Boolean?): BooleanExpression? {
-        return isVisit?.let { universityEntity.isVisit.eq(it) }
-    }
+    private fun isVisitEq(isVisit: Boolean?): BooleanExpression? = isVisit?.let { universityEntity.isVisit.eq(it) }
 
-    private fun searchKeyword(search: String?): BooleanExpression? {
-        return search?.let {
-            universityEntity.nameKor.contains(it)
+    private fun searchKeyword(search: String?): BooleanExpression? =
+        search?.let {
+            universityEntity.nameKor
+                .contains(it)
                 .or(universityEntity.nameEng.contains(it))
         }
-    }
 
-    private fun gpaLoe(gpa: Double?): BooleanExpression? {
-        return gpa?.let { universityEntity.minGpa.loe(it) }
-    }
+    private fun gpaLoe(gpa: Double?): BooleanExpression? = gpa?.let { universityEntity.minGpa.loe(it) }
 
-    private fun majorContains(major: String?): BooleanExpression? {
-        return major?.let { universityEntity.availableMajor.contains(it) }
-    }
+    private fun majorContains(major: String?): BooleanExpression? = major?.let { universityEntity.availableMajor.contains(it) }
 
-    private fun hasReviewEq(hasReview: Boolean?): BooleanExpression? {
-        return hasReview?.let { universityEntity.hasReview.eq(it) }
-    }
+    private fun hasReviewEq(hasReview: Boolean?): BooleanExpression? = hasReview?.let { universityEntity.hasReview.eq(it) }
 
     private fun examScoresMatch(examScores: Map<String, Double>): BooleanExpression? {
         if (examScores.isEmpty()) return null
 
-        val examConditions = examScores.map { (examType, score) ->
-            // JLPT는 숫자가 낮을수록 높은 레벨 (N1 > N2 > ... > N5)
-            val scoreCondition = if (examType == ExamType.JLPT.displayName) {
-                languageRequirementEntity.minScore.goe(score)
-            } else {
-                languageRequirementEntity.minScore.loe(score)
-            }
+        val examConditions =
+            examScores
+                .map { (examType, score) ->
+                    // JLPT는 숫자가 낮을수록 높은 레벨 (N1 > N2 > ... > N5)
+                    val scoreCondition =
+                        if (examType == ExamType.JLPT.displayName) {
+                            languageRequirementEntity.minScore.goe(score)
+                        } else {
+                            languageRequirementEntity.minScore.loe(score)
+                        }
 
-            languageRequirementEntity.examType.eq(examType).and(scoreCondition)
-        }.reduce { acc, condition -> acc.or(condition) }
+                    languageRequirementEntity.examType.eq(examType).and(scoreCondition)
+                }.reduce { acc, condition -> acc.or(condition) }
 
         // 조건을 만족하는 language_requirement가 존재하는 경우
-        val hasMatchingRequirement = JPAExpressions
-            .selectOne()
-            .from(languageRequirementEntity)
-            .where(
-                languageRequirementEntity.universityId.eq(universityEntity.id),
-                examConditions
-            )
-            .exists()
+        val hasMatchingRequirement =
+            JPAExpressions
+                .selectOne()
+                .from(languageRequirementEntity)
+                .where(
+                    languageRequirementEntity.universityId.eq(universityEntity.id),
+                    examConditions,
+                ).exists()
 
         // language_requirement 자체가 없는 경우 (어학 요구사항 없음)
-        val hasNoRequirement = JPAExpressions
-            .selectOne()
-            .from(languageRequirementEntity)
-            .where(
-                languageRequirementEntity.universityId.eq(universityEntity.id)
-            )
-            .notExists()
+        val hasNoRequirement =
+            JPAExpressions
+                .selectOne()
+                .from(languageRequirementEntity)
+                .where(
+                    languageRequirementEntity.universityId.eq(universityEntity.id),
+                ).notExists()
 
         // 둘 중 하나라도 true면 조회 가능
         return hasMatchingRequirement.or(hasNoRequirement)

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/storage/UniversityRepositoryImpl.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/storage/UniversityRepositoryImpl.kt
@@ -20,7 +20,8 @@ class UniversityRepositoryImpl(
 ) : UniversityRepository {
 
     override fun findAllWithFilters(
-        nation: String?,
+        nations: List<String>?,
+        region: String?,
         isExchange: Boolean?,
         isVisit: Boolean?,
         search: String?,
@@ -34,7 +35,8 @@ class UniversityRepositoryImpl(
         val query = queryFactory
             .selectFrom(universityEntity)
             .where(
-                nationEq(nation),
+                nationsIn(nations),
+                regionEq(region),
                 isExchangeEq(isExchange),
                 isVisitEq(isVisit),
                 searchKeyword(search),
@@ -60,7 +62,8 @@ class UniversityRepositoryImpl(
             .select(universityEntity.count())
             .from(universityEntity)
             .where(
-                nationEq(nation),
+                nationsIn(nations),
+                regionEq(region),
                 isExchangeEq(isExchange),
                 isVisitEq(isVisit),
                 searchKeyword(search),
@@ -78,8 +81,12 @@ class UniversityRepositoryImpl(
         return universityJpaRepository.findById(id).orElse(null)?.toDomain()
     }
 
-    private fun nationEq(nation: String?): BooleanExpression? {
-        return nation?.let { universityEntity.nation.eq(it) }
+    private fun nationsIn(nations: List<String>?): BooleanExpression? {
+        return nations?.takeIf { it.isNotEmpty() }?.let { universityEntity.nation.`in`(it) }
+    }
+
+    private fun regionEq(region: String?): BooleanExpression? {
+        return region?.let { universityEntity.region.eq(it) }
     }
 
     private fun isExchangeEq(isExchange: Boolean?): BooleanExpression? {
@@ -99,13 +106,6 @@ class UniversityRepositoryImpl(
 
     private fun gpaLoe(gpa: Double?): BooleanExpression? {
         return gpa?.let { universityEntity.minGpa.loe(it) }
-    }
-
-    private fun nationsIn(nations: String?): BooleanExpression? {
-        return nations?.let {
-            val nationList = it.split(",").map { nation -> nation.trim() }
-            universityEntity.nation.`in`(nationList)
-        }
     }
 
     private fun majorContains(major: String?): BooleanExpression? {

--- a/src/test/kotlin/org/example/beyondubackend/BeyondUBackendApplicationTests.kt
+++ b/src/test/kotlin/org/example/beyondubackend/BeyondUBackendApplicationTests.kt
@@ -5,9 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
 class BeyondUBackendApplicationTests {
-
-	@Test
-	fun contextLoads() {
-	}
-
+    @Test
+    fun contextLoads() {
+    }
 }

--- a/src/test/kotlin/org/example/beyondubackend/common/LoggingAspectTest.kt
+++ b/src/test/kotlin/org/example/beyondubackend/common/LoggingAspectTest.kt
@@ -11,7 +11,6 @@ import org.springframework.test.context.ActiveProfiles
 @SpringBootTest
 @ActiveProfiles("test")
 class LoggingAspectTest {
-
     @Autowired
     lateinit var sampleService: SampleService
 
@@ -28,15 +27,20 @@ class LoggingAspectTest {
 
 @Service
 class SampleService {
-
     @Loggable
-    fun search(keyword: String, gpa: Double): String {
+    fun search(
+        keyword: String,
+        gpa: Double,
+    ): String {
         Thread.sleep(30)
         return "result:$keyword"
     }
 
     @Loggable
-    fun login(email: String, @LogMask password: String): Boolean {
+    fun login(
+        email: String,
+        @LogMask password: String,
+    ): Boolean {
         Thread.sleep(10)
         return true
     }

--- a/src/test/kotlin/org/example/beyondubackend/domain/university/flow/UniversityFlowTest.kt
+++ b/src/test/kotlin/org/example/beyondubackend/domain/university/flow/UniversityFlowTest.kt
@@ -63,6 +63,7 @@ class UniversityFlowTest {
             nameKor = "도쿄대학교", nameEng = "University of Tokyo",
             nation = "JPN", minGpa = 3.5,
             isExchange = true, isVisit = false,
+            region = "아시아",
             availableMajor = "Engineering",
             location = "Tokyo, Japan", studentCount = "28,000"
         ))
@@ -77,13 +78,15 @@ class UniversityFlowTest {
             nation = "CHN", minGpa = 3.8,
             isExchange = true, isVisit = false,
             hasReview = true, reviewYear = "2023",
+            region = "아시아",
             availableMajor = "Business, Economics",
             location = "Beijing, China", studentCount = "55,000"
         ))
         uni5 = universityJpaRepository.save(makeUniversity(
             nameKor = "멜버른대학교", nameEng = "University of Melbourne",
             nation = "AUS", minGpa = 2.0,
-            isExchange = true, isVisit = false
+            isExchange = true, isVisit = false,
+            region = "오세아니아"
         ))
 
         languageRequirementJpaRepository.saveAll(listOf(
@@ -192,7 +195,7 @@ class UniversityFlowTest {
 
     @Test
     fun `나라 USA + GPA 3점5 + TOEFL IBT 80점 조합 시 조건 모두 충족하는 미국 대학만 반환된다`() {
-        val response = get<Map<String, Any?>>("$baseUrl?nation=USA&gpa=3.5&TOEFL_IBT=80")
+        val response = get<Map<String, Any?>>("$baseUrl?nations=USA&gpa=3.5&TOEFL_IBT=80")
 
         val ids = universityIds(response)
         // USA: uni1, uni3 / GPA: uni1(3.0), uni3(2.5) / 어학: uni1 TOEFL 충족, uni3 없음
@@ -201,18 +204,17 @@ class UniversityFlowTest {
 
     @Test
     fun `나라 USA + GPA 3점5 + 어학 2개(OR) 조합 시 미국 대학 중 조건 충족 반환`() {
-        val response = get<Map<String, Any?>>("$baseUrl?nation=USA&gpa=3.5&TOEFL_IBT=80&IELTS=6.0")
+        val response = get<Map<String, Any?>>("$baseUrl?nations=USA&gpa=3.5&TOEFL_IBT=80&IELTS=6.0")
 
         val ids = universityIds(response)
         assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni3.id)
     }
 
     @Test
-    fun `나라 JPN + GPA 4점0 + JLPT 2 조합 시 도쿄대가 반환된다`() {
-        val response = get<Map<String, Any?>>("$baseUrl?nation=JPN&gpa=4.0&JLPT=2")
+    fun `유효하지 않은 nations 코드 JPN 사용 시 400 에러가 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?nations=JPN&gpa=4.0&JLPT=2")
 
-        val ids = universityIds(response)
-        assertThat(ids).containsExactlyInAnyOrder(uni2.id)
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
     }
 
     // ── 전체 조회: JLPT 역방향 필터 ────────────────────────────────────────
@@ -240,7 +242,7 @@ class UniversityFlowTest {
 
     @Test
     fun `국가 USA 필터 시 미국 대학만 반환된다`() {
-        val response = get<Map<String, Any?>>("$baseUrl?nation=USA")
+        val response = get<Map<String, Any?>>("$baseUrl?nations=USA")
 
         val ids = universityIds(response)
         assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni3.id)
@@ -300,7 +302,7 @@ class UniversityFlowTest {
 
     @Test
     fun `일치하는 대학이 없으면 빈 리스트와 totalElements 0이 반환된다`() {
-        val response = get<Map<String, Any?>>("$baseUrl?nation=DEU")
+        val response = get<Map<String, Any?>>("$baseUrl?nations=GERMANY")
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         val result = result(response)
@@ -433,6 +435,48 @@ class UniversityFlowTest {
         assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
     }
 
+    // ── 전체 조회: nations 복수 OR 조건 (#37) ──────────────────────────────
+
+    @Test
+    fun `nations 단일 값은 해당 국가 대학만 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?nations=USA")
+
+        val ids = universityIds(response)
+        assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni3.id)
+    }
+
+    @Test
+    fun `유효하지 않은 nations 코드 JPN 포함 시 400 에러가 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?nations=USA&nations=JPN")
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+    }
+
+    @Test
+    fun `유효하지 않은 nations 코드 AUS 포함 시 400 에러가 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?nations=USA&nations=JPN&nations=AUS")
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+    }
+
+    // ── 전체 조회: region 대륙 필터 (#37) ──────────────────────────────────
+    // 픽스처 region: uni1/uni3=미주, uni2/uni4=아시아, uni5=오세아니아
+
+    @Test
+    fun `유효하지 않은 region 이름 사용 시 400 에러가 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?region=없는대륙")
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+    }
+
+    @Test
+    fun `region 아시아 필터 시 아시아 대학만 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?region=아시아")
+
+        val ids = universityIds(response)
+        assertThat(ids).containsExactlyInAnyOrder(uni2.id, uni4.id)
+    }
+
     // ── 헬퍼 ────────────────────────────────────────────────────────────────
 
     @Suppress("UNCHECKED_CAST")
@@ -460,13 +504,14 @@ class UniversityFlowTest {
         isVisit: Boolean = false,
         hasReview: Boolean = false,
         reviewYear: String? = null,
+        region: String = "미주",
         availableMajor: String? = null,
         availableSubject: String? = null,
         location: String? = null,
         studentCount: String? = null
     ) = UniversityEntity(
         semester = "2024-1",
-        region = "미주",
+        region = region,
         nation = nation,
         nameKor = nameKor,
         nameEng = nameEng,

--- a/src/test/kotlin/org/example/beyondubackend/domain/university/flow/UniversityFlowTest.kt
+++ b/src/test/kotlin/org/example/beyondubackend/domain/university/flow/UniversityFlowTest.kt
@@ -18,7 +18,6 @@ import org.springframework.test.context.ActiveProfiles
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 class UniversityFlowTest {
-
     @LocalServerPort
     private var port: Int = 0
 
@@ -51,50 +50,87 @@ class UniversityFlowTest {
         languageRequirementJpaRepository.deleteAll()
         universityJpaRepository.deleteAll()
 
-        uni1 = universityJpaRepository.save(makeUniversity(
-            nameKor = "하버드대학교", nameEng = "Harvard University",
-            nation = "USA", minGpa = 3.0,
-            isExchange = true, isVisit = false,
-            hasReview = true, reviewYear = "2024",
-            availableMajor = "Arts and Sciences, Business",
-            location = "Cambridge, MA", studentCount = "47,000"
-        ))
-        uni2 = universityJpaRepository.save(makeUniversity(
-            nameKor = "도쿄대학교", nameEng = "University of Tokyo",
-            nation = "JPN", minGpa = 3.5,
-            isExchange = true, isVisit = false,
-            region = "아시아",
-            availableMajor = "Engineering",
-            location = "Tokyo, Japan", studentCount = "28,000"
-        ))
-        uni3 = universityJpaRepository.save(makeUniversity(
-            nameKor = "캘리포니아주립대", nameEng = "California State University",
-            nation = "USA", minGpa = 2.5,
-            isExchange = false, isVisit = true,
-            location = "Los Angeles, CA"
-        ))
-        uni4 = universityJpaRepository.save(makeUniversity(
-            nameKor = "베이징대학교", nameEng = "Peking University",
-            nation = "CHN", minGpa = 3.8,
-            isExchange = true, isVisit = false,
-            hasReview = true, reviewYear = "2023",
-            region = "아시아",
-            availableMajor = "Business, Economics",
-            location = "Beijing, China", studentCount = "55,000"
-        ))
-        uni5 = universityJpaRepository.save(makeUniversity(
-            nameKor = "멜버른대학교", nameEng = "University of Melbourne",
-            nation = "AUS", minGpa = 2.0,
-            isExchange = true, isVisit = false,
-            region = "오세아니아"
-        ))
+        uni1 =
+            universityJpaRepository.save(
+                makeUniversity(
+                    nameKor = "하버드대학교",
+                    nameEng = "Harvard University",
+                    nation = "USA",
+                    minGpa = 3.0,
+                    isExchange = true,
+                    isVisit = false,
+                    hasReview = true,
+                    reviewYear = "2024",
+                    availableMajor = "Arts and Sciences, Business",
+                    location = "Cambridge, MA",
+                    studentCount = "47,000",
+                ),
+            )
+        uni2 =
+            universityJpaRepository.save(
+                makeUniversity(
+                    nameKor = "도쿄대학교",
+                    nameEng = "University of Tokyo",
+                    nation = "JPN",
+                    minGpa = 3.5,
+                    isExchange = true,
+                    isVisit = false,
+                    region = "아시아",
+                    availableMajor = "Engineering",
+                    location = "Tokyo, Japan",
+                    studentCount = "28,000",
+                ),
+            )
+        uni3 =
+            universityJpaRepository.save(
+                makeUniversity(
+                    nameKor = "캘리포니아주립대",
+                    nameEng = "California State University",
+                    nation = "USA",
+                    minGpa = 2.5,
+                    isExchange = false,
+                    isVisit = true,
+                    location = "Los Angeles, CA",
+                ),
+            )
+        uni4 =
+            universityJpaRepository.save(
+                makeUniversity(
+                    nameKor = "베이징대학교",
+                    nameEng = "Peking University",
+                    nation = "CHN",
+                    minGpa = 3.8,
+                    isExchange = true,
+                    isVisit = false,
+                    hasReview = true,
+                    reviewYear = "2023",
+                    region = "아시아",
+                    availableMajor = "Business, Economics",
+                    location = "Beijing, China",
+                    studentCount = "55,000",
+                ),
+            )
+        uni5 =
+            universityJpaRepository.save(
+                makeUniversity(
+                    nameKor = "멜버른대학교",
+                    nameEng = "University of Melbourne",
+                    nation = "AUS",
+                    minGpa = 2.0,
+                    isExchange = true,
+                    isVisit = false,
+                    region = "오세아니아",
+                ),
+            )
 
-        languageRequirementJpaRepository.saveAll(listOf(
-            makeLangReq(uni1.id!!, "영어", "TOEFL iBT", 80.0),
-            makeLangReq(uni1.id!!, "영어", "IELTS", 6.0),
-            makeLangReq(uni2.id!!, "일본어", "JLPT", 2.0),
-            makeLangReq(uni4.id!!, "영어", "TOEFL iBT", 100.0)
-        ))
+        languageRequirementJpaRepository.saveAll(
+            listOf(
+                makeLangReq(uni1.id!!, "영어", "TOEFL iBT", 80.0),
+                makeLangReq(uni1.id!!, "영어", "IELTS", 6.0),
+                makeLangReq(uni2.id!!, "일본어", "JLPT", 2.0),
+                makeLangReq(uni4.id!!, "영어", "TOEFL iBT", 100.0),
+            ),
+        )
     }
 
     @AfterEach
@@ -337,7 +373,7 @@ class UniversityFlowTest {
 
     @Test
     fun `TOEFL IBT 점수가 120 초과이면 400 에러가 반환된다`() {
-        val response = get<Map<String, Any?>>( "$baseUrl?TOEFL_IBT=999")
+        val response = get<Map<String, Any?>>("$baseUrl?TOEFL_IBT=999")
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
     }
@@ -368,6 +404,7 @@ class UniversityFlowTest {
         val response = get<Map<String, Any?>>("$baseUrl/${uni1.id}")
 
         val detail = result(response)
+
         @Suppress("UNCHECKED_CAST")
         val majors = detail["availableMajors"] as List<String>
         assertThat(majors).containsExactlyInAnyOrder("Arts and Sciences", "Business")
@@ -376,10 +413,14 @@ class UniversityFlowTest {
     @Test
     fun `상세 조회 시 courseListUrl은 availableSubject 필드 값이다`() {
         val url = "https://example.com/courses"
-        val saved = universityJpaRepository.save(makeUniversity(
-            nameKor = "URL테스트대학", nameEng = "URL Test University",
-            availableSubject = url
-        ))
+        val saved =
+            universityJpaRepository.save(
+                makeUniversity(
+                    nameKor = "URL테스트대학",
+                    nameEng = "URL Test University",
+                    availableSubject = url,
+                ),
+            )
 
         val response = get<Map<String, Any?>>("$baseUrl/${saved.id}")
 
@@ -400,6 +441,7 @@ class UniversityFlowTest {
         val response = get<Map<String, Any?>>("$baseUrl/${uni1.id}")
 
         val detail = result(response)
+
         @Suppress("UNCHECKED_CAST")
         val langReqs = detail["languageRequirements"] as List<Map<String, Any?>>
         assertThat(langReqs).hasSize(2)
@@ -412,6 +454,7 @@ class UniversityFlowTest {
         val response = get<Map<String, Any?>>("$baseUrl/${uni5.id}")
 
         val detail = result(response)
+
         @Suppress("UNCHECKED_CAST")
         val langReqs = detail["languageRequirements"] as List<*>
         assertThat(langReqs).isEmpty()
@@ -491,9 +534,10 @@ class UniversityFlowTest {
     private fun universities(response: org.springframework.http.ResponseEntity<Map<String, Any?>>) =
         (result(response)["universities"] as List<Map<String, Any?>>)
 
-    private fun universityIds(response: org.springframework.http.ResponseEntity<Map<String, Any?>>): List<Long> {
-        return universities(response).map { (it["id"] as Number).toLong() }
-    }
+    private fun universityIds(response: org.springframework.http.ResponseEntity<Map<String, Any?>>): List<Long> =
+        universities(response).map {
+            (it["id"] as Number).toLong()
+        }
 
     private fun makeUniversity(
         nameKor: String = "테스트대학",
@@ -508,7 +552,7 @@ class UniversityFlowTest {
         availableMajor: String? = null,
         availableSubject: String? = null,
         location: String? = null,
-        studentCount: String? = null
+        studentCount: String? = null,
     ) = UniversityEntity(
         semester = "2024-1",
         region = region,
@@ -524,7 +568,7 @@ class UniversityFlowTest {
         availableMajor = availableMajor,
         availableSubject = availableSubject,
         location = location,
-        studentCount = studentCount
+        studentCount = studentCount,
     )
 
     private fun makeLangReq(
@@ -532,12 +576,12 @@ class UniversityFlowTest {
         languageGroup: String,
         examType: String,
         minScore: Double,
-        levelCode: String? = null
+        levelCode: String? = null,
     ) = LanguageRequirementEntity(
         universityId = universityId,
         languageGroup = languageGroup,
         examType = examType,
         minScore = minScore,
-        levelCode = levelCode
+        levelCode = levelCode,
     )
 }

--- a/src/test/kotlin/org/example/beyondubackend/domain/university/unit/LanguageRequirementSummaryTest.kt
+++ b/src/test/kotlin/org/example/beyondubackend/domain/university/unit/LanguageRequirementSummaryTest.kt
@@ -12,7 +12,6 @@ import org.mockito.junit.jupiter.MockitoExtension
 
 @ExtendWith(MockitoExtension::class)
 class LanguageRequirementSummaryTest {
-
     @Mock
     private lateinit var languageRequirementRepository: LanguageRequirementRepository
 
@@ -48,10 +47,11 @@ class LanguageRequirementSummaryTest {
 
     @Test
     fun `복수 요구사항은 슬래시로 구분하여 모두 표시된다`() {
-        val requirements = listOf(
-            req("TOEFL iBT", 100.0),
-            req("IELTS", 7.0)
-        )
+        val requirements =
+            listOf(
+                req("TOEFL iBT", 100.0),
+                req("IELTS", 7.0),
+            )
 
         val result = reader.generateSummary(requirements)
 
@@ -79,11 +79,12 @@ class LanguageRequirementSummaryTest {
 
     @Test
     fun `세 개 이상 요구사항도 슬래시로 올바르게 연결된다`() {
-        val requirements = listOf(
-            req("TOEFL iBT", 80.0),
-            req("TOEIC", 700.0),
-            req("IELTS", 6.0)
-        )
+        val requirements =
+            listOf(
+                req("TOEFL iBT", 80.0),
+                req("TOEIC", 700.0),
+                req("IELTS", 6.0),
+            )
 
         val result = reader.generateSummary(requirements)
 
@@ -96,12 +97,12 @@ class LanguageRequirementSummaryTest {
     private fun req(
         examType: String,
         minScore: Double,
-        levelCode: String? = null
+        levelCode: String? = null,
     ) = LanguageRequirement(
         universityId = 1L,
         languageGroup = "영어",
         examType = examType,
         minScore = minScore,
-        levelCode = levelCode
+        levelCode = levelCode,
     )
 }

--- a/src/test/kotlin/org/example/beyondubackend/domain/university/unit/UniversityDetailResponseTest.kt
+++ b/src/test/kotlin/org/example/beyondubackend/domain/university/unit/UniversityDetailResponseTest.kt
@@ -5,6 +5,7 @@ import org.example.beyondubackend.domain.university.business.dto.LanguageRequire
 import org.example.beyondubackend.domain.university.business.dto.UniversityDetailResponse
 import org.example.beyondubackend.domain.university.implement.University
 import org.junit.jupiter.api.Test
+import java.util.Base64
 
 class UniversityDetailResponseTest {
 
@@ -105,6 +106,48 @@ class UniversityDetailResponseTest {
         assertThat(result.programType).isEqualTo("")
     }
 
+    @Test
+    fun `isExchange와 isVisit 모두 true이면 isExchange가 우선되어 programType이 일반교환이다`() {
+        val university = makeUniversity(isExchange = true, isVisit = true)
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        assertThat(result.programType).isEqualTo("일반교환")
+    }
+
+    // ── reviewReportUrl (#38) ────────────────────────────────────────────────
+
+    @Test
+    fun `hasReview true이면 reviewReportUrl이 nameEng Base64 인코딩 URL로 반환된다`() {
+        val university = makeUniversity(hasReview = true, nameEng = "Harvard University")
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        val encoded = Base64.getEncoder().encodeToString("Harvard University".toByteArray())
+        assertThat(result.reviewReportUrl)
+            .isEqualTo("https://study.ssu.ac.kr/community/exp_list.do?searchVal=$encoded&siteCd=01&boardCd=07")
+    }
+
+    @Test
+    fun `hasReview false이면 reviewReportUrl이 null이다`() {
+        val university = makeUniversity(hasReview = false, nameEng = "Harvard University")
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        assertThat(result.reviewReportUrl).isNull()
+    }
+
+    @Test
+    fun `nameEng에 공백이 포함된 경우에도 Base64 인코딩이 정확하다`() {
+        val university = makeUniversity(hasReview = true, nameEng = "University of Melbourne")
+
+        val result = UniversityDetailResponse.from(university, emptyList())
+
+        val encoded = Base64.getEncoder().encodeToString("University of Melbourne".toByteArray())
+        assertThat(result.reviewReportUrl)
+            .isEqualTo("https://study.ssu.ac.kr/community/exp_list.do?searchVal=$encoded&siteCd=01&boardCd=07")
+    }
+
     // ── location / studentCount 직접 매핑 ──────────────────────────────────
 
     @Test
@@ -164,6 +207,8 @@ class UniversityDetailResponseTest {
         id: Long = 1L,
         isExchange: Boolean = true,
         isVisit: Boolean = false,
+        hasReview: Boolean = false,
+        nameEng: String = "Test University",
         availableMajor: String? = null,
         availableSubject: String? = null,
         location: String? = null,
@@ -174,11 +219,12 @@ class UniversityDetailResponseTest {
         region = "미주",
         nation = "USA",
         nameKor = "테스트대학교",
-        nameEng = "Test University",
+        nameEng = nameEng,
         minGpa = 3.0,
         remark = "특이사항 없음",
         isExchange = isExchange,
         isVisit = isVisit,
+        hasReview = hasReview,
         availableMajor = availableMajor,
         availableSubject = availableSubject,
         location = location,

--- a/src/test/kotlin/org/example/beyondubackend/domain/university/unit/UniversityDetailResponseTest.kt
+++ b/src/test/kotlin/org/example/beyondubackend/domain/university/unit/UniversityDetailResponseTest.kt
@@ -5,10 +5,9 @@ import org.example.beyondubackend.domain.university.business.dto.LanguageRequire
 import org.example.beyondubackend.domain.university.business.dto.UniversityDetailResponse
 import org.example.beyondubackend.domain.university.implement.University
 import org.junit.jupiter.api.Test
-import java.util.Base64
+import java.util.*
 
 class UniversityDetailResponseTest {
-
     // ── availableMajors 파싱 (availableMajor DB 필드 → 콤마 분리 리스트) ───
 
     @Test
@@ -191,9 +190,10 @@ class UniversityDetailResponseTest {
     @Test
     fun `전달된 languageRequirements 리스트가 그대로 포함된다`() {
         val university = makeUniversity()
-        val langReqs = listOf(
-            LanguageRequirementResponse(languageGroup = "영어", examType = "TOEFL iBT", minScore = 80.0)
-        )
+        val langReqs =
+            listOf(
+                LanguageRequirementResponse(languageGroup = "영어", examType = "TOEFL iBT", minScore = 80.0),
+            )
 
         val result = UniversityDetailResponse.from(university, langReqs)
 
@@ -212,7 +212,7 @@ class UniversityDetailResponseTest {
         availableMajor: String? = null,
         availableSubject: String? = null,
         location: String? = null,
-        studentCount: String? = null
+        studentCount: String? = null,
     ) = University(
         id = id,
         semester = "2024-1",
@@ -228,6 +228,6 @@ class UniversityDetailResponseTest {
         availableMajor = availableMajor,
         availableSubject = availableSubject,
         location = location,
-        studentCount = studentCount
+        studentCount = studentCount,
     )
 }

--- a/src/test/kotlin/org/example/beyondubackend/domain/university/unit/UniversityReaderTest.kt
+++ b/src/test/kotlin/org/example/beyondubackend/domain/university/unit/UniversityReaderTest.kt
@@ -15,7 +15,6 @@ import org.mockito.junit.jupiter.MockitoExtension
 
 @ExtendWith(MockitoExtension::class)
 class UniversityReaderTest {
-
     @Mock
     private lateinit var universityRepository: UniversityRepository
 
@@ -36,23 +35,28 @@ class UniversityReaderTest {
 
     @Test
     fun `존재하는 ID로 조회 시 University 도메인 객체가 반환된다`() {
-        val university = org.example.beyondubackend.domain.university.implement.University(
-            id = 1L,
-            semester = "2024-1",
-            region = "미주",
-            nation = "USA",
-            nameKor = "하버드대학교",
-            nameEng = "Harvard University",
-            minGpa = 3.0,
-            remark = "특이사항 없음",
-            isExchange = true,
-            isVisit = false
-        )
+        val university =
+            org.example.beyondubackend.domain.university.implement.University(
+                id = 1L,
+                semester = "2024-1",
+                region = "미주",
+                nation = "USA",
+                nameKor = "하버드대학교",
+                nameEng = "Harvard University",
+                minGpa = 3.0,
+                remark = "특이사항 없음",
+                isExchange = true,
+                isVisit = false,
+            )
         given(universityRepository.findById(1L)).willReturn(university)
 
         val result = universityReader.getUniversityById(1L)
 
-        org.assertj.core.api.Assertions.assertThat(result.id).isEqualTo(1L)
-        org.assertj.core.api.Assertions.assertThat(result.nameKor).isEqualTo("하버드대학교")
+        org.assertj.core.api.Assertions
+            .assertThat(result.id)
+            .isEqualTo(1L)
+        org.assertj.core.api.Assertions
+            .assertThat(result.nameKor)
+            .isEqualTo("하버드대학교")
     }
 }


### PR DESCRIPTION
closes #37 #38 

---

## 구현 기능

### 1. nations 복수 OR 조건 검색
- `UniversitySearchRequest`: `nations: List<String>?` 추가
  - 기존 `nation: String?`은 하위 호환을 위해 유지, `nations`와 병합 후 중복 제거
- 유효성 검사: **Nation enum의 name** 기준으로 검증
  - enum에 없는 코드는 `400 BAD_REQUEST` 반환
  - **nation 코드는 Nation enum으로만 관리** — enum 외 코드는 허용하지 않음
- `UniversityRepositoryImpl`: `nationsIn()` 메서드 활성화 (기존 미사용 → OR 조건 적용)

### 2. region 대륙 필터 추가
- `UniversitySearchRequest`: `region: String?` 추가
- 유효성 검사: **Region enum의 displayName** 기준으로 검증
  - enum에 없는 값은 `400 BAD_REQUEST` 반환
  - **region 값은 Region enum으로만 관리** — enum 외 문자열은 허용하지 않음
- `Region` enum 신규 추가: 유럽 / 아시아 / 북미 / 남미 / 오세아니아 / 아프리카
- `MetaController`: `GET /api/v1/meta/regions` 엔드포인트 추가

### 3. 후기 보고서 URL 추가
- `UniversityDetailResponse`: `reviewReportUrl: String?` 필드 추가
  - `hasReview = true`: `nameEng`를 UTF-8 Base64 인코딩하여 URL 생성
  - `hasReview = false`: `null` 반환

**실행 예시**
```
// 복수 국가 OR 조건
GET /api/v1/universities?nations=JAPAN&nations=USA

// 대륙 필터
GET /api/v1/universities?region=아시아

// 유효하지 않은 코드 → 400
GET /api/v1/universities?nations=JPN
GET /api/v1/universities?region=미주

// 대륙 목록 조회
GET /api/v1/meta/regions

// 대학 상세 (후기 있음)
GET /api/v1/universities/{id}
→ "reviewReportUrl": "https://study.ssu.ac.kr/community/exp_list.do?searchVal=SGFydmFyZCBVbml2ZXJzaXR5&siteCd=01&boardCd=07"
```

---

## 참고사항

- 현재 배포사항을 고려하여 nation, nations 파라미터 모두 허용. 추후 nation 삭제 예정