### PR TITLE
[#40] feat: 언어권 필터 추가 및 region·nations 복수 OR 조건 검색으로 변경

### DIFF
--- a/src/main/kotlin/org/example/beyondubackend/common/enums/LanguageGroup.kt
+++ b/src/main/kotlin/org/example/beyondubackend/common/enums/LanguageGroup.kt
@@ -1,0 +1,12 @@
+package org.example.beyondubackend.common.enums
+
+enum class LanguageGroup {
+    ENGLISH,
+    GERMAN,
+    ITALIAN,
+    SPANISH,
+    FRENCH,
+    CHINESE,
+    JAPANESE,
+    ;
+}

--- a/src/main/kotlin/org/example/beyondubackend/domain/meta/application/MetaController.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/meta/application/MetaController.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.example.beyondubackend.common.dto.ApiResponse
 import org.example.beyondubackend.common.enums.ExamType
+import org.example.beyondubackend.common.enums.LanguageGroup
 import org.example.beyondubackend.common.enums.Nation
 import org.example.beyondubackend.common.enums.Region
 import org.example.beyondubackend.domain.meta.application.dto.ExamTypeResponse
@@ -28,6 +29,13 @@ class MetaController {
     fun getRegions(): ResponseEntity<ApiResponse<List<String>>> {
         val regions = Region.entries.map { it.displayName }
         return ApiResponse.success(regions)
+    }
+
+    @Operation(summary = "언어권 목록 조회", description = "university 필터링에 사용 가능한 언어권 목록을 반환합니다.")
+    @GetMapping("/language-groups")
+    fun getLanguageGroups(): ResponseEntity<ApiResponse<List<String>>> {
+        val languageGroups = LanguageGroup.entries.map { it.name }
+        return ApiResponse.success(languageGroups)
     }
 
     @Operation(summary = "어학 시험 목록 조회", description = "지원하는 어학 시험 종류와 점수 범위를 반환합니다.")

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/application/dto/UniversitySearchRequest.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/application/dto/UniversitySearchRequest.kt
@@ -2,18 +2,21 @@ package org.example.beyondubackend.domain.university.application.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.example.beyondubackend.common.code.ErrorCode
+import org.example.beyondubackend.common.enums.LanguageGroup
 import org.example.beyondubackend.common.enums.Nation
 import org.example.beyondubackend.common.enums.Region
 import org.example.beyondubackend.common.exception.BusinessException
 import org.example.beyondubackend.domain.university.business.query.UniversityQuery
 
-data class UniversitySearchRequest(
+data class  UniversitySearchRequest(
     @Schema(description = "국가 필터 단일값 (하위 호환, 예: ?nation=USA)")
     val nation: String? = null,
     @Schema(description = "국가 필터 복수값 (예: ?nations=USA&nations=JPN)", example = "USA")
     val nations: List<String>? = null,
-    @Schema(description = "대륙 필터 (예: 유럽, 아시아, 북미, 남미, 오세아니아, 아프리카)")
-    val region: String? = null,
+    @Schema(description = "대륙 필터 복수값 (예: ?regions=아시아&regions=유럽)")
+    val regions: List<String>? = null,
+    @Schema(description = "언어권 필터 복수값 (예: ?languageGroups=ENGLISH&languageGroups=JAPANESE)", example = "ENGLISH")
+    val languageGroups: List<String>? = null,
     @Schema(description = "교환학생 가능 여부")
     val isExchange: Boolean? = null,
     @Schema(description = "방문학생 가능 여부")
@@ -37,11 +40,13 @@ data class UniversitySearchRequest(
                 .takeIf { it.isNotEmpty() }
 
         validateNations(mergedNations)
-        validateRegion(region)
+        validateRegions(regions)
+        validateLanguageGroups(languageGroups)
 
         return UniversityQuery(
             nations = mergedNations,
-            region = region,
+            regions = regions,
+            languageGroups = languageGroups,
             isExchange = isExchange,
             isVisit = isVisit,
             search = search,
@@ -54,18 +59,28 @@ data class UniversitySearchRequest(
 
     private fun validateNations(nations: List<String>?) {
         if (nations.isNullOrEmpty()) return
-        val validNames = Nation.entries.map { it.name }.toSet()
+        val validNames = Nation.entries.map { it.displayName }.toSet()
         val invalid = nations.filter { it !in validNames }
         if (invalid.isNotEmpty()) {
-            throw BusinessException(ErrorCode.INVALID_INPUT, "유효하지 않은 국가 코드: ${invalid.joinToString()}")
+            throw BusinessException(ErrorCode.INVALID_INPUT, "유효하지 않은 국가: ${invalid.joinToString()}")
         }
     }
 
-    private fun validateRegion(region: String?) {
-        if (region == null) return
+    private fun validateRegions(regions: List<String>?) {
+        if (regions.isNullOrEmpty()) return
         val validNames = Region.entries.map { it.displayName }.toSet()
-        if (region !in validNames) {
-            throw BusinessException(ErrorCode.INVALID_INPUT, "유효하지 않은 대륙: $region")
+        val invalid = regions.filter { it !in validNames }
+        if (invalid.isNotEmpty()) {
+            throw BusinessException(ErrorCode.INVALID_INPUT, "유효하지 않은 대륙: ${invalid.joinToString()}")
+        }
+    }
+
+    private fun validateLanguageGroups(languageGroups: List<String>?) {
+        if (languageGroups.isNullOrEmpty()) return
+        val validNames = LanguageGroup.entries.map { it.name }.toSet()
+        val invalid = languageGroups.filter { it !in validNames }
+        if (invalid.isNotEmpty()) {
+            throw BusinessException(ErrorCode.INVALID_INPUT, "유효하지 않은 언어권: ${invalid.joinToString()}")
         }
     }
 }

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/business/UniversityServiceImpl.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/business/UniversityServiceImpl.kt
@@ -24,7 +24,8 @@ class UniversityServiceImpl(
         val universityPage =
             universityReader.getUniversitiesWithFilters(
                 nations = query.nations,
-                region = query.region,
+                regions = query.regions,
+                languageGroups = query.languageGroups,
                 isExchange = query.isExchange,
                 isVisit = query.isVisit,
                 search = query.search,
@@ -35,10 +36,8 @@ class UniversityServiceImpl(
                 pageable = pageable,
             )
 
-        // 대학 ID 목록 추출
-        val universityIds = universityPage.content.map { it.id!! }
+        val universityIds = universityPage.content.mapNotNull { it.id }
 
-        // 언어 요구사항 일괄 조회
         val languageRequirementsMap =
             if (universityIds.isNotEmpty()) {
                 languageRequirementReader.findByUniversityIds(universityIds)
@@ -46,7 +45,6 @@ class UniversityServiceImpl(
                 emptyMap()
             }
 
-        // DTO 변환 (languageRequirementSummary 포함)
         val universities =
             universityPage.content.map { university ->
                 val requirements = languageRequirementsMap[university.id] ?: emptyList()

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/business/query/UniversityQuery.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/business/query/UniversityQuery.kt
@@ -2,7 +2,8 @@ package org.example.beyondubackend.domain.university.business.query
 
 data class UniversityQuery(
     val nations: List<String>? = null,
-    val region: String? = null,
+    val regions: List<String>? = null,
+    val languageGroups: List<String>? = null,
     val isExchange: Boolean? = null,
     val isVisit: Boolean? = null,
     val search: String? = null,

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/implement/UniversityReader.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/implement/UniversityReader.kt
@@ -12,7 +12,8 @@ class UniversityReader(
 ) {
     fun getUniversitiesWithFilters(
         nations: List<String>?,
-        region: String?,
+        regions: List<String>?,
+        languageGroups: List<String>?,
         isExchange: Boolean?,
         isVisit: Boolean?,
         search: String?,
@@ -24,7 +25,8 @@ class UniversityReader(
     ): Page<University> =
         universityRepository.findAllWithFilters(
             nations,
-            region,
+            regions,
+            languageGroups,
             isExchange,
             isVisit,
             search,

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/implement/UniversityRepository.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/implement/UniversityRepository.kt
@@ -6,7 +6,8 @@ import org.springframework.data.domain.Pageable
 interface UniversityRepository {
     fun findAllWithFilters(
         nations: List<String>?,
-        region: String?,
+        regions: List<String>?,
+        languageGroups: List<String>?,
         isExchange: Boolean?,
         isVisit: Boolean?,
         search: String?,

--- a/src/main/kotlin/org/example/beyondubackend/domain/university/storage/UniversityRepositoryImpl.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/university/storage/UniversityRepositoryImpl.kt
@@ -20,7 +20,8 @@ class UniversityRepositoryImpl(
 ) : UniversityRepository {
     override fun findAllWithFilters(
         nations: List<String>?,
-        region: String?,
+        regions: List<String>?,
+        languageGroups: List<String>?,
         isExchange: Boolean?,
         isVisit: Boolean?,
         search: String?,
@@ -35,7 +36,8 @@ class UniversityRepositoryImpl(
                 .selectFrom(universityEntity)
                 .where(
                     nationsIn(nations),
-                    regionEq(region),
+                    regionsIn(regions),
+                    languageGroupsIn(languageGroups),
                     isExchangeEq(isExchange),
                     isVisitEq(isVisit),
                     searchKeyword(search),
@@ -70,7 +72,8 @@ class UniversityRepositoryImpl(
                 .from(universityEntity)
                 .where(
                     nationsIn(nations),
-                    regionEq(region),
+                    regionsIn(regions),
+                    languageGroupsIn(languageGroups),
                     isExchangeEq(isExchange),
                     isVisitEq(isVisit),
                     searchKeyword(search),
@@ -91,7 +94,21 @@ class UniversityRepositoryImpl(
                 it.isNotEmpty()
             }?.let { universityEntity.nation.`in`(it) }
 
-    private fun regionEq(region: String?): BooleanExpression? = region?.let { universityEntity.region.eq(it) }
+    private fun regionsIn(regions: List<String>?): BooleanExpression? =
+        regions
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { universityEntity.region.`in`(it) }
+
+    private fun languageGroupsIn(languageGroups: List<String>?): BooleanExpression? {
+        if (languageGroups.isNullOrEmpty()) return null
+        return JPAExpressions
+            .selectOne()
+            .from(languageRequirementEntity)
+            .where(
+                languageRequirementEntity.universityId.eq(universityEntity.id),
+                languageRequirementEntity.languageGroup.`in`(languageGroups),
+            ).exists()
+    }
 
     private fun isExchangeEq(isExchange: Boolean?): BooleanExpression? = isExchange?.let { universityEntity.isExchange.eq(it) }
 

--- a/src/test/kotlin/org/example/beyondubackend/domain/university/flow/UniversityFlowTest.kt
+++ b/src/test/kotlin/org/example/beyondubackend/domain/university/flow/UniversityFlowTest.kt
@@ -33,11 +33,11 @@ class UniversityFlowTest {
     private val baseUrl get() = "http://localhost:$port/api/v1/universities"
 
     // ── 픽스처 ──────────────────────────────────────────────────────────────
-    // uni1: USA, GPA 3.0, 교환, TOEFL iBT 80 / IELTS 6.0, 후기 있음
-    // uni2: JPN, GPA 3.5, 교환, JLPT N2(minScore=2)
-    // uni3: USA, GPA 2.5, 방문, 어학 요구사항 없음
-    // uni4: CHN, GPA 3.8, 교환, TOEFL iBT 100, 후기 있음
-    // uni5: AUS, GPA 2.0, 교환, 어학 요구사항 없음
+    // uni1: 미국, GPA 3.0, 교환, TOEFL iBT 80 / IELTS 6.0, 후기 있음
+    // uni2: 일본, GPA 3.5, 교환, JLPT N2(minScore=2)
+    // uni3: 미국, GPA 2.5, 방문, 어학 요구사항 없음
+    // uni4: 중국, GPA 3.8, 교환, TOEFL iBT 100, 후기 있음
+    // uni5: 호주, GPA 2.0, 교환, 어학 요구사항 없음
 
     private lateinit var uni1: UniversityEntity
     private lateinit var uni2: UniversityEntity
@@ -55,7 +55,7 @@ class UniversityFlowTest {
                 makeUniversity(
                     nameKor = "하버드대학교",
                     nameEng = "Harvard University",
-                    nation = "USA",
+                    nation = "미국",
                     minGpa = 3.0,
                     isExchange = true,
                     isVisit = false,
@@ -71,7 +71,7 @@ class UniversityFlowTest {
                 makeUniversity(
                     nameKor = "도쿄대학교",
                     nameEng = "University of Tokyo",
-                    nation = "JPN",
+                    nation = "일본",
                     minGpa = 3.5,
                     isExchange = true,
                     isVisit = false,
@@ -86,7 +86,7 @@ class UniversityFlowTest {
                 makeUniversity(
                     nameKor = "캘리포니아주립대",
                     nameEng = "California State University",
-                    nation = "USA",
+                    nation = "미국",
                     minGpa = 2.5,
                     isExchange = false,
                     isVisit = true,
@@ -98,7 +98,7 @@ class UniversityFlowTest {
                 makeUniversity(
                     nameKor = "베이징대학교",
                     nameEng = "Peking University",
-                    nation = "CHN",
+                    nation = "중국",
                     minGpa = 3.8,
                     isExchange = true,
                     isVisit = false,
@@ -115,7 +115,7 @@ class UniversityFlowTest {
                 makeUniversity(
                     nameKor = "멜버른대학교",
                     nameEng = "University of Melbourne",
-                    nation = "AUS",
+                    nation = "호주",
                     minGpa = 2.0,
                     isExchange = true,
                     isVisit = false,
@@ -125,10 +125,10 @@ class UniversityFlowTest {
 
         languageRequirementJpaRepository.saveAll(
             listOf(
-                makeLangReq(uni1.id!!, "영어", "TOEFL iBT", 80.0),
-                makeLangReq(uni1.id!!, "영어", "IELTS", 6.0),
-                makeLangReq(uni2.id!!, "일본어", "JLPT", 2.0),
-                makeLangReq(uni4.id!!, "영어", "TOEFL iBT", 100.0),
+                makeLangReq(uni1.id!!, "ENGLISH", "TOEFL iBT", 80.0),
+                makeLangReq(uni1.id!!, "ENGLISH", "IELTS", 6.0),
+                makeLangReq(uni2.id!!, "JAPANESE", "JLPT", 2.0),
+                makeLangReq(uni4.id!!, "ENGLISH", "TOEFL iBT", 100.0),
             ),
         )
     }
@@ -230,24 +230,24 @@ class UniversityFlowTest {
     // ── 전체 조회: 국가 + GPA + 어학 복합 필터 ─────────────────────────────
 
     @Test
-    fun `나라 USA + GPA 3점5 + TOEFL IBT 80점 조합 시 조건 모두 충족하는 미국 대학만 반환된다`() {
-        val response = get<Map<String, Any?>>("$baseUrl?nations=USA&gpa=3.5&TOEFL_IBT=80")
+    fun `나라 미국 + GPA 3점5 + TOEFL IBT 80점 조합 시 조건 모두 충족하는 미국 대학만 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?nations=미국&gpa=3.5&TOEFL_IBT=80")
 
         val ids = universityIds(response)
-        // USA: uni1, uni3 / GPA: uni1(3.0), uni3(2.5) / 어학: uni1 TOEFL 충족, uni3 없음
+        // 미국: uni1, uni3 / GPA: uni1(3.0), uni3(2.5) / 어학: uni1 TOEFL 충족, uni3 없음
         assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni3.id)
     }
 
     @Test
-    fun `나라 USA + GPA 3점5 + 어학 2개(OR) 조합 시 미국 대학 중 조건 충족 반환`() {
-        val response = get<Map<String, Any?>>("$baseUrl?nations=USA&gpa=3.5&TOEFL_IBT=80&IELTS=6.0")
+    fun `나라 미국 + GPA 3점5 + 어학 2개(OR) 조합 시 미국 대학 중 조건 충족 반환`() {
+        val response = get<Map<String, Any?>>("$baseUrl?nations=미국&gpa=3.5&TOEFL_IBT=80&IELTS=6.0")
 
         val ids = universityIds(response)
         assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni3.id)
     }
 
     @Test
-    fun `유효하지 않은 nations 코드 JPN 사용 시 400 에러가 반환된다`() {
+    fun `Nation enum에 존재하지 않는 국가명 JPN 사용 시 400 에러가 반환된다`() {
         val response = get<Map<String, Any?>>("$baseUrl?nations=JPN&gpa=4.0&JLPT=2")
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
@@ -277,8 +277,8 @@ class UniversityFlowTest {
     // ── 전체 조회: 기타 단독 필터 ──────────────────────────────────────────
 
     @Test
-    fun `국가 USA 필터 시 미국 대학만 반환된다`() {
-        val response = get<Map<String, Any?>>("$baseUrl?nations=USA")
+    fun `국가 미국 필터 시 미국 대학만 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?nations=미국")
 
         val ids = universityIds(response)
         assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni3.id)
@@ -338,7 +338,7 @@ class UniversityFlowTest {
 
     @Test
     fun `일치하는 대학이 없으면 빈 리스트와 totalElements 0이 반환된다`() {
-        val response = get<Map<String, Any?>>("$baseUrl?nations=GERMANY")
+        val response = get<Map<String, Any?>>("$baseUrl?nations=영국")
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         val result = result(response)
@@ -482,22 +482,23 @@ class UniversityFlowTest {
 
     @Test
     fun `nations 단일 값은 해당 국가 대학만 반환된다`() {
-        val response = get<Map<String, Any?>>("$baseUrl?nations=USA")
+        val response = get<Map<String, Any?>>("$baseUrl?nations=미국")
 
         val ids = universityIds(response)
         assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni3.id)
     }
 
     @Test
-    fun `유효하지 않은 nations 코드 JPN 포함 시 400 에러가 반환된다`() {
-        val response = get<Map<String, Any?>>("$baseUrl?nations=USA&nations=JPN")
+    fun `nations 복수 OR 조건으로 미국과 일본 필터 시 해당 대학들이 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?nations=미국&nations=일본")
 
-        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        val ids = universityIds(response)
+        assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni2.id, uni3.id)
     }
 
     @Test
-    fun `유효하지 않은 nations 코드 AUS 포함 시 400 에러가 반환된다`() {
-        val response = get<Map<String, Any?>>("$baseUrl?nations=USA&nations=JPN&nations=AUS")
+    fun `Nation enum에 존재하지 않는 국가명 사용 시 400 에러가 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?nations=없는나라")
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
     }
@@ -506,18 +507,52 @@ class UniversityFlowTest {
     // 픽스처 region: uni1/uni3=미주, uni2/uni4=아시아, uni5=오세아니아
 
     @Test
-    fun `유효하지 않은 region 이름 사용 시 400 에러가 반환된다`() {
-        val response = get<Map<String, Any?>>("$baseUrl?region=없는대륙")
+    fun `유효하지 않은 regions 이름 사용 시 400 에러가 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?regions=없는대륙")
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
     }
 
     @Test
-    fun `region 아시아 필터 시 아시아 대학만 반환된다`() {
-        val response = get<Map<String, Any?>>("$baseUrl?region=아시아")
+    fun `regions 아시아 필터 시 아시아 대학만 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?regions=아시아")
 
         val ids = universityIds(response)
         assertThat(ids).containsExactlyInAnyOrder(uni2.id, uni4.id)
+    }
+
+    @Test
+    fun `regions 복수 OR 조건으로 아시아와 오세아니아 필터 시 해당 대학들이 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?regions=아시아&regions=오세아니아")
+
+        val ids = universityIds(response)
+        assertThat(ids).containsExactlyInAnyOrder(uni2.id, uni4.id, uni5.id)
+    }
+
+    // ── 전체 조회: 언어권 필터 (#37) ────────────────────────────────────────
+    // 픽스처 languageGroup: uni1/uni4=ENGLISH, uni2=JAPANESE, uni3/uni5=어학 요구사항 없음
+
+    @Test
+    fun `언어권 필터 ENGLISH 단일 선택 시 ENGLISH 어학 요구사항이 있는 대학만 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?languageGroups=ENGLISH")
+
+        val ids = universityIds(response)
+        assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni4.id)
+    }
+
+    @Test
+    fun `언어권 필터 ENGLISH JAPANESE 복수 선택 시 둘 중 하나라도 있는 대학이 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?languageGroups=ENGLISH&languageGroups=JAPANESE")
+
+        val ids = universityIds(response)
+        assertThat(ids).containsExactlyInAnyOrder(uni1.id, uni2.id, uni4.id)
+    }
+
+    @Test
+    fun `유효하지 않은 언어권 코드 KOREAN 사용 시 400 에러가 반환된다`() {
+        val response = get<Map<String, Any?>>("$baseUrl?languageGroups=KOREAN")
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
     }
 
     // ── 헬퍼 ────────────────────────────────────────────────────────────────
@@ -542,7 +577,7 @@ class UniversityFlowTest {
     private fun makeUniversity(
         nameKor: String = "테스트대학",
         nameEng: String = "Test University",
-        nation: String = "USA",
+        nation: String = "미국",
         minGpa: Double = 3.0,
         isExchange: Boolean = true,
         isVisit: Boolean = false,


### PR DESCRIPTION
closes #40

---

## 구현 기능

### 언어권(languageGroups) 필터 추가
- `LanguageGroup` enum 추가 (`ENGLISH` / `GERMAN` / `ITALIAN` / `SPANISH` / `FRENCH` / `CHINESE` / `JAPANESE`)
- `GET /api/v1/universities?languageGroups=ENGLISH&languageGroups=JAPANESE` — OR 조건, language_requirement 테이블 EXISTS 서브쿼리로 필터링
- `GET /api/v1/meta/language-groups` — 언어권 목록 meta API 추가

### region 단일 → regions 복수 OR 조건으로 변경
- `region: String?` → `regions: List<String>?` 변경, IN 조건 필터링

### nations 검증 기준 수정 (버그 수정)
- 기존: enum name(`USA`) 기준 검증 → DB(`미국`)와 불일치로 필터링 무효
- 수정: enum displayName(`미국`) 기준 검증 → meta API·DB 모두 한국어로 일치

**파라미터 기준**
| 파라미터 | 형식 | 예시 |
|---|---|---|
| `nations` | 한국어 | `미국`, `일본` |
| `regions` | 한국어 | `아시아`, `북미` |
| `languageGroups` | 영어 대문자 | `ENGLISH`, `JAPANESE` |

**실행 예시**
```
GET /api/v1/universities?languageGroups=ENGLISH&languageGroups=JAPANESE
GET /api/v1/universities?regions=아시아&regions=유럽
GET /api/v1/universities?nations=미국&regions=북미&languageGroups=ENGLISH
GET /api/v1/meta/language-groups
→ ["ENGLISH", "GERMAN", "ITALIAN", "SPANISH", "FRENCH", "CHINESE", "JAPANESE"]
```

---

## 참고사항
- `languageGroups` 필터는 language_requirement 테이블 EXISTS 서브쿼리 사용 (기존 `examScoresMatch()` 패턴 동일)
- `nations` / `regions` 필터는 University 테이블 컬럼 직접 IN 조건
- 유효하지 않은 값 입력 시 400 반환