### PR TITLE
[#47]; refactor: meta/nations 이전 버전 롤백 및 v2 엔드포인트 분리

### DIFF
--- a/src/main/kotlin/org/example/beyondubackend/domain/meta/application/MetaController.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/meta/application/MetaController.kt
@@ -8,7 +8,6 @@ import org.example.beyondubackend.common.enums.LanguageGroup
 import org.example.beyondubackend.common.enums.Region
 import org.example.beyondubackend.domain.meta.application.dto.ExamTypeResponse
 import org.example.beyondubackend.domain.meta.application.dto.MajorCategoryResponse
-import org.example.beyondubackend.domain.meta.application.dto.NationsByRegionResponse
 import org.example.beyondubackend.domain.meta.business.MetaService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,10 +20,11 @@ import org.springframework.web.bind.annotation.RestController
 class MetaController(
     private val metaService: MetaService,
 ) {
-    @Operation(summary = "국가 목록 조회 (지역별 그룹핑)", description = "대륙별로 그룹핑된 국가 목록을 반환합니다.")
+    @Operation(summary = "국가 목록 조회", description = "university 필터링에 사용 가능한 국가 목록을 반환합니다.")
     @GetMapping("/nations")
-    fun getNations(): ResponseEntity<ApiResponse<List<NationsByRegionResponse>>> =
-        ApiResponse.success(metaService.getNationsByRegion())
+    fun getNations(): ResponseEntity<ApiResponse<List<String>>> =
+        ApiResponse.success(metaService.getNations())
+
 
     @Operation(summary = "전공 목록 조회 (카테고리별 그룹핑)", description = "카테고리별로 그룹핑된 전공 목록을 반환합니다.")
     @GetMapping("/majors")

--- a/src/main/kotlin/org/example/beyondubackend/domain/meta/application/MetaV2Controller.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/meta/application/MetaV2Controller.kt
@@ -1,0 +1,23 @@
+package org.example.beyondubackend.domain.meta.application
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.example.beyondubackend.common.dto.ApiResponse
+import org.example.beyondubackend.domain.meta.application.dto.NationsByRegionResponse
+import org.example.beyondubackend.domain.meta.business.MetaService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Meta", description = "공통 코드 조회 API")
+@RestController
+@RequestMapping("/api/v2/meta")
+class MetaV2Controller(
+    private val metaService: MetaService,
+) {
+    @Operation(summary = "국가 목록 조회 (지역별 그룹핑)", description = "대륙별로 그룹핑된 국가 목록을 반환합니다.")
+    @GetMapping("/nations")
+    fun getNations(): ResponseEntity<ApiResponse<List<NationsByRegionResponse>>> =
+        ApiResponse.success(metaService.getNationsByRegion())
+}

--- a/src/main/kotlin/org/example/beyondubackend/domain/meta/business/MetaService.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/meta/business/MetaService.kt
@@ -4,6 +4,8 @@ import org.example.beyondubackend.domain.meta.application.dto.MajorCategoryRespo
 import org.example.beyondubackend.domain.meta.application.dto.NationsByRegionResponse
 
 interface MetaService {
+    fun getNations(): List<String>
+
     fun getNationsByRegion(): List<NationsByRegionResponse>
 
     fun getMajors(): List<MajorCategoryResponse>

--- a/src/main/kotlin/org/example/beyondubackend/domain/meta/business/MetaServiceImpl.kt
+++ b/src/main/kotlin/org/example/beyondubackend/domain/meta/business/MetaServiceImpl.kt
@@ -1,9 +1,6 @@
 package org.example.beyondubackend.domain.meta.business
 
-import org.example.beyondubackend.common.enums.KoreanMajor
-import org.example.beyondubackend.common.enums.MajorCategory
-import org.example.beyondubackend.common.enums.Region
-import org.example.beyondubackend.common.enums.SubMajor
+import org.example.beyondubackend.common.enums.*
 import org.example.beyondubackend.domain.meta.application.dto.MajorCategoryResponse
 import org.example.beyondubackend.domain.meta.application.dto.NationsByRegionResponse
 import org.example.beyondubackend.domain.meta.application.dto.SubMajorResponse
@@ -14,6 +11,8 @@ import org.springframework.stereotype.Service
 class MetaServiceImpl(
     private val universityReader: UniversityReader,
 ) : MetaService {
+    override fun getNations(): List<String> = Nation.entries.map { it.displayName }
+
     override fun getNationsByRegion(): List<NationsByRegionResponse> {
         val regionOrder = Region.entries.map { it.displayName }
         return universityReader.getDistinctRegionAndNation()


### PR DESCRIPTION
## Summary

- `GET /api/v1/meta/nations` → `List<String>` 으로 롤백 (Nation enum 기반, 클라이언트 호환 복원)
- `GET /api/v2/meta/nations` 신규 추가 → `List<NationsByRegionResponse>` (지역별 그룹핑, 기존 v1 로직 이동)
- `MetaV2Controller` 분리, `MetaService.getNations()` 추가

## Test plan

- [x] `GET /api/v1/meta/nations` → `List<String>` 응답 확인 (국가명 문자열 배열)
- [x] `GET /api/v2/meta/nations` → `List<NationsByRegionResponse>` 응답 확인 (지역별 그룹핑)
- [x] Swagger UI에서 v1/v2 엔드포인트 각각 노출 확인

Closes #47